### PR TITLE
Verilator support for all cores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - AXI4 memory controller option on vc707
 - Multicore Verilator simulation using DPI alternative to existing PLI
 - Simulation of OpenPiton+Ariane with VCS
+- Simulation of OpenPiton+Ariane with Verilator
 
 ### Changed
 - Remove BUFG and clock gating latches for FPGA targets
@@ -19,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Rewrite SD controller. Cross-timing-domain hazards fixed
 - Update Xilinx IPs to Vivado 2016.4
 - Moved to CAM structure for L2 MSHR to improve timing
+- Changed generate if blocks in tile to reflect restrictions with Verilator. Functionality is unchanged.
 
 ## Release 11
 

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -679,7 +679,8 @@ NIB_SIZE = pow(2, NIB_SIZE_LOG2)
 // Instantiate Cores //
 ///////////////////////
 generate
-if (TILE_TYPE == `SPARC_TILE) begin : g_core
+if (TILE_TYPE == `SPARC_TILE) begin : g_sparc_core
+//for (genvar i = 0;(TILE_TYPE == `SPARC_TILE) && (i == 0);i = i + 1) begin
     ////////////////
     // SPARC Core //
     ////////////////
@@ -819,7 +820,11 @@ if (TILE_TYPE == `SPARC_TILE) begin : g_core
     );
 
 
-end else if (TILE_TYPE == `PICORV32_TILE) begin : g_core
+end
+endgenerate
+generate
+if (TILE_TYPE == `PICORV32_TILE) begin : g_picorv32_core
+//for (genvar i = 0;(TILE_TYPE == `PICORV32_TILE) && (i == 0);i = i + 1) begin : g_picorv32_core
     ///////////////////
     // PicoRV32 Core //
     ///////////////////
@@ -896,7 +901,11 @@ end else if (TILE_TYPE == `PICORV32_TILE) begin : g_core
         .pico_int                           (pico_int)
     );
 
-end else if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_core
+end
+endgenerate
+generate
+if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_ariane_core
+//for (genvar i = 0;(TILE_TYPE == `ARIANE_RV64_TILE) && (i == 0);i = i + 1) begin : g_ariane_core
     //////////////////////
     // Ariane RV64 Core //
     //////////////////////

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -680,7 +680,6 @@ NIB_SIZE = pow(2, NIB_SIZE_LOG2)
 ///////////////////////
 generate
 if (TILE_TYPE == `SPARC_TILE) begin : g_sparc_core
-//for (genvar i = 0;(TILE_TYPE == `SPARC_TILE) && (i == 0);i = i + 1) begin
     ////////////////
     // SPARC Core //
     ////////////////
@@ -824,7 +823,6 @@ end
 endgenerate
 generate
 if (TILE_TYPE == `PICORV32_TILE) begin : g_picorv32_core
-//for (genvar i = 0;(TILE_TYPE == `PICORV32_TILE) && (i == 0);i = i + 1) begin : g_picorv32_core
     ///////////////////
     // PicoRV32 Core //
     ///////////////////
@@ -905,7 +903,6 @@ end
 endgenerate
 generate
 if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_ariane_core
-//for (genvar i = 0;(TILE_TYPE == `ARIANE_RV64_TILE) && (i == 0);i = i + 1) begin : g_ariane_core
     //////////////////////
     // Ariane RV64 Core //
     //////////////////////

--- a/piton/verif/env/manycore/cross_module.h.pyv
+++ b/piton/verif/env/manycore/cross_module.h.pyv
@@ -99,11 +99,20 @@
 for i in range(NUM_TILES):
     printstring = """
     `define TILE%d            `CHIP.tile%d
-    `define ARIANE_CORE%d     `TILE%d.g_core.core.ariane
-    `define SPARC_CORE%d      `TILE%d.g_core.core
-    `define PICO_CORE%d       `TILE%d.g_core.core
-    `define CCX_TRANSDUCER%d  `TILE%d.g_core.ccx_l15_transducer
-    `define PICO_TRANSDUCER%d `TILE%d.g_core.pico_l15_transducer
+    `define ARIANE_CORE%d     `TILE%d.g_ariane_core.core.ariane
+    `define SPARC_CORE%d      `TILE%d.g_sparc_core.core
+    `define PICO_CORE%d       `TILE%d.g_picorv32_core.core
+    `ifdef RTL_SPARC%d
+    `define CORE_REF%d        `SPARC_CORE%d
+    `endif // ifdef RTL_SPARC%d
+    `ifdef RTL_ARIANE%d
+    `define CORE_REF%d        `TILE%d.g_ariane_core.core
+    `endif // ifdef RTL_ARIANE%d
+    `ifdef RTL_PICO%d
+    `define CORE_REF%d        `PICO_CORE%d
+    `endif // ifdef RTL_PICO%d
+    `define CCX_TRANSDUCER%d  `TILE%d.g_sparc_core.ccx_l15_transducer
+    `define PICO_TRANSDUCER%d `TILE%d.g_picorv32_core.pico_l15_transducer
     `define L15_TOP%d         `TILE%d.l15.l15
     `define L15_PIPE%d        `TILE%d.l15.l15.pipeline
     `define DMBR%d            `TILE%d.dmbr_ins

--- a/piton/verif/env/manycore/manycore_top.v.pyv
+++ b/piton/verif/env/manycore/manycore_top.v.pyv
@@ -487,7 +487,7 @@ system system(
 
 `ifndef VERILATOR
     // T1's TSO monitor, stripped of all L2 references
-    tso_mon tso_mon(`CHIP_INT_CLK, `SPARC_CORE0.reset_l);
+    tso_mon tso_mon(`CHIP_INT_CLK, `CORE_REF0.reset_l);
 `endif
 
     // L15 MONITORS
@@ -535,7 +535,7 @@ system system(
     sas_intf  sas_intf(/*AUTOINST*/
         // Inputs
         .clk       (`CHIP_INT_CLK),      // Templated
-        .rst_l     (`SPARC_CORE0.reset_l));       // Templated
+        .rst_l     (`CORE_REF0.reset_l));       // Templated
 `endif
 `endif
 
@@ -545,7 +545,7 @@ system system(
     sas_tasks sas_tasks(/*AUTOINST*/
         // Inputs
         .clk      (`CHIP_INT_CLK),      // Templated
-        .rst_l        (`SPARC_CORE0.reset_l));       // Templated
+        .rst_l        (`CORE_REF0.reset_l));       // Templated
 `endif
 `endif
 

--- a/piton/verif/env/manycore/manycore_top.v.pyv
+++ b/piton/verif/env/manycore/manycore_top.v.pyv
@@ -430,7 +430,7 @@ system system(
     monitor   monitor(
         .clk    (`CHIP_INT_CLK),
         .cmp_gclk  (`CHIP_INT_CLK),
-        .rst_l     (`SPARC_CORE0.reset_l)
+        .rst_l     (`CORE_REF0.reset_l)
         );
 
 `ifndef MINIMAL_MONITORING


### PR DESCRIPTION
We use generate for instantiating the different cores inside `tile.v.pyv`. The simulators handled this fine except for Verilator. Verilator would only evaluate the first `if` branch to look for module instantiations and so the cross-module references would break if you tried to use a different core that wasn't in the first `if` branch (sparc by default). The solution (used in this PR) is to make multiple independent generate if blocks. This is functionally equivalent as `TILE_TYPE` can only be set to one value. It does require changing some cross-module references to make it work. The simulations that I've run since all continued to behave as expected.

One minor change that's still needed for ariane simulation is adding some `ifndef VERILATOR` macros into ariane's instruction tracer files.