### PR TITLE
L2 fix for more than 8 cores in one dimension

### DIFF
--- a/piton/design/chip/tile/common/rtl/Flist.network_common
+++ b/piton/design/chip/tile/common/rtl/Flist.network_common
@@ -1,3 +1,4 @@
 credit_to_valrdy.v
 valrdy_to_credit.v
 flat_id_to_xy.v
+xy_to_flat_id.v

--- a/piton/design/chip/tile/common/rtl/piton_tile_common.core
+++ b/piton/design/chip/tile/common/rtl/piton_tile_common.core
@@ -29,4 +29,5 @@ generate:
     pyhp_preprocess:
         generator: pyhp_preprocess_gen
         parameters:
-            process_me : [[flat_id_to_xy.v.pyv, flat_id_to_xy.tmp.v]]
+            process_me : [[flat_id_to_xy.v.pyv, flat_id_to_xy.tmp.v],
+                          [xy_to_flat_id.v.pyv, xy_to_flat_id.tmp.v]]

--- a/piton/design/chip/tile/common/rtl/xy_to_flat_id.v.pyv
+++ b/piton/design/chip/tile/common/rtl/xy_to_flat_id.v.pyv
@@ -33,34 +33,46 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %>
 
 
-module flat_id_to_xy(
-    input  [(`HOME_ID_WIDTH-1):0] flat_id,
-    output reg [(`NOC_X_WIDTH-1):0] x_coord,
-    output reg [(`NOC_Y_WIDTH-1):0] y_coord
+module xy_to_flat_id(
+    input  [(`NOC_X_WIDTH-1):0] x_coord,
+    input  [(`NOC_Y_WIDTH-1):0] y_coord,
+    output reg [(`HOME_ID_WIDTH-1):0] flat_id
 );
-
+    
+    
     always @*
     begin
-        case (flat_id)
+        case (x_coord)
         <%
         text = '''
-        //(`NOC_Y_WIDTH+`NOC_X_WIDTH)'difield: 
-        `HOME_ID_WIDTH'difield: 
-        begin
-            x_coord = `NOC_X_WIDTH'dxfield;
-            y_coord = `NOC_Y_WIDTH'dyfield;
-        end'''
-        for i in range(NUM_TILES):
-            tt = text.replace("ifield", str(i))
-            tt = tt.replace("xfield", str(i%X_TILES))
-            tt = tt.replace("yfield", str(i/X_TILES))
-            print tt
+            // (x,y) = (xfield, yfield)
+            `NOC_Y_WIDTH'dyfield:
+            begin
+                flat_id = `HOME_ID_WIDTH'difield;
+            end'''
+        for i in range(X_TILES):
+            print ""
+            print "`NOC_X_WIDTH'd%d:" % (i)
+            print "begin"
+            print "     case (y_coord)"
+
+            for j in range(Y_TILES):
+                tt = text.replace("yfield", str(j))   
+                tt = tt.replace("xfield", str(i))   
+                tt = tt.replace("ifield", str(j*X_TILES + i))
+                print tt
+            print "     default:"
+            print "     begin"
+            print "         flat_id = `HOME_ID_WIDTH'dX;"
+            print "     end"
+            print "     endcase"
+            print "end"
         %>
         default:
         begin
-            x_coord = `NOC_X_WIDTH'dX;
-            y_coord = `NOC_X_WIDTH'dX;
+            flat_id = `HOME_ID_WIDTH'dX;
         end
         endcase
     end
 endmodule
+

--- a/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
+++ b/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
@@ -495,9 +495,6 @@ begin
         end
         else
         begin
-            // csm_l15_res_data_s3 = {{`NOC_CHIPID_WIDTH{1'b0}},
-            //                       {(`NOC_X_WIDTH-`HOME_ID_Y_POS_WIDTH){1'b0}}, lhid_s3[`HOME_ID_Y_POS],
-            //                       {(`NOC_X_WIDTH-`HOME_ID_X_POS_WIDTH){1'b0}}, lhid_s3[`HOME_ID_X_POS]};
             csm_l15_res_data_s3 = 0;
             csm_l15_res_data_s3[`PACKET_HOME_ID_CHIP_MASK] = 1'b0; // non-csm mode only has 1 chip alone
             csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = lhid_s3_y;
@@ -507,49 +504,10 @@ begin
 end
 
 flat_id_to_xy lhid_to_xy (
-    .flat_id(lhid_s3[`HOME_ID_Y_POS_WIDTH+`HOME_ID_X_POS_WIDTH-1:0]),
+    .flat_id(lhid_s3[`HOME_ID_WIDTH-1:0]),
     .x_coord(lhid_s3_x),
     .y_coord(lhid_s3_y)
     );
-
-/*
-always @ *
-begin
-    if (csm_en)
-    begin
-      refill_req_val_s3 = rd_en_s3 && (~diag_en_s3) && (~flush_en_s3) && (~hit_s3);
-       ;
-      // csm_l15_res_data_s3 = data_out_s3;
-      // csm_l15_res_valid_s3 = valid_out_s3;
-      // csm_l15_res_tag_s3 = tag_out_s3;
-      if (diag_en_s3 && rd_en_s3 && (addr_op_s3 == 1))
-      begin
-        csm_l15_res_data_s3 = valid_out_s3;
-      end
-      else if (diag_en_s3 && rd_en_s3 && (addr_op_s3 == 2))
-      begin
-        csm_l15_res_data_s3 = tag_out_s3;
-      end
-      else
-      begin
-        csm_l15_res_data_s3 = data_out_s3; // TODO: mux this with valid and tag
-      end
-    end
-    else
-    begin
-      // non-csm mode
-      refill_req_val_s3 = 1'b0;
-      csm_l15_res_val_s3 = l15_csm_req_val_s3;
-      // csm_l15_res_data_s3 = {{`NOC_CHIPID_WIDTH{1'b0}},
-      //                       {(`NOC_X_WIDTH-`HOME_ID_Y_POS_WIDTH){1'b0}}, lhid_s3[`HOME_ID_Y_POS],
-      //                       {(`NOC_X_WIDTH-`HOME_ID_X_POS_WIDTH){1'b0}}, lhid_s3[`HOME_ID_X_POS]};
-      csm_l15_res_data_s3 = 0;
-      csm_l15_res_data_s3[`PACKET_HOME_ID_CHIP_MASK] = 1'b0; // non-csm mode only has 1 chip alone
-      csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = lhid_s3[`HOME_ID_Y_POS];
-      csm_l15_res_data_s3[`PACKET_HOME_ID_X_MASK] = lhid_s3[`HOME_ID_X_POS];
-    end
-end
-*/
 
 
 
@@ -796,9 +754,6 @@ assign csm_noc1encoder_req_size = 0;
 
 always @ *
 begin
-    // csm_l15_res_data_s3 = {{`NOC_CHIPID_WIDTH{1'b0}},
-    //                       {(`NOC_X_WIDTH-`HOME_ID_Y_POS_WIDTH){1'b0}}, lhid_s3[`HOME_ID_Y_POS],
-    //                       {(`NOC_X_WIDTH-`HOME_ID_X_POS_WIDTH){1'b0}}, lhid_s3[`HOME_ID_X_POS]};
     csm_l15_res_data_s3 = 0;
     csm_l15_res_data_s3[`PACKET_HOME_ID_CHIP_MASK] = 1'b0; // non-csm mode only has 1 chip alone
     csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = lhid_s3_y;
@@ -806,7 +761,7 @@ begin
 end
 
 flat_id_to_xy lhid_to_xy (
-    .flat_id(lhid_s3[`HOME_ID_Y_POS_WIDTH+`HOME_ID_X_POS_WIDTH-1:0]),
+    .flat_id(lhid_s3[`HOME_ID_WIDTH-1:0]),
     .x_coord(lhid_s3_x),
     .y_coord(lhid_s3_y)
     );

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_dpath.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_dpath.v.pyv
@@ -561,6 +561,14 @@ begin
     end
 end
 
+wire [`L2_OWNER_BITS-1:0] flat_id_S2;
+
+xy_to_flat_id flat_id_gen(
+    .flat_id    (flat_id_S2),
+    .x_coord    (src_x_S2_f),
+    .y_coord    (src_y_S2_f)
+);
+
 
 reg [`L2_STATE_ARRAY_WIDTH-1:0] state_data_buf_S2_f;
 reg [`L2_STATE_ARRAY_WIDTH-1:0] state_data_buf_S2_next;
@@ -844,7 +852,7 @@ begin
     else
     `endif
     begin
-        req_from_owner_S2 = (l2_way_state_owner_S2 == {src_y_S2_f[`L2_OWNER_XY], src_x_S2_f[`L2_OWNER_XY]});
+        req_from_owner_S2 = (l2_way_state_owner_S2 == flat_id_S2);
     end
 end
 
@@ -968,10 +976,12 @@ begin
         else    
         `endif
         begin
-            dir_data_mask_in_S2 = {{(`L2_DIR_ARRAY_WIDTH-1){1'b0}},1'b1} << {src_y_S2_f[`L2_OWNER_XY], src_x_S2_f[`L2_OWNER_XY]};
+            dir_data_mask_in_S2 = {{(`L2_DIR_ARRAY_WIDTH-1){1'b0}},1'b1} << flat_id_S2;
         end
     end 
 end
+
+
 
 reg [`L2_DATA_DATA_WIDTH-1:0] msg_data_mask_in_S2;
 reg [`L2_DATA_DATA_WIDTH-1:0] data_data_merge_S2;
@@ -1104,7 +1114,7 @@ begin
         else
         `endif
         begin
-            state_owner_S2 = {src_y_S2_f[`L2_OWNER_XY], src_x_S2_f[`L2_OWNER_XY]}; 
+            state_owner_S2 = flat_id_S2; // {src_y_S2_f[`L2_OWNER_XY], src_x_S2_f[`L2_OWNER_XY]}; 
         end
     end
     else if (state_owner_op_S2 == `OP_ADD)
@@ -1887,6 +1897,20 @@ begin
     end
 end
 
+wire [(`NOC_X_WIDTH-1) : 0] owner_x_S4; 
+wire [(`NOC_Y_WIDTH-1) : 0] owner_y_S4; 
+wire [(`NOC_X_WIDTH-1) : 0] sharer_x_S4; 
+wire [(`NOC_Y_WIDTH-1) : 0] sharer_y_S4; 
+flat_id_to_xy owner_xy_gen(
+    .flat_id            (l2_way_state_owner_S4_f),
+    .x_coord            (owner_x_S4),
+    .y_coord            (owner_y_S4)
+);
+flat_id_to_xy sharer_xy_gen(
+    .flat_id            (dir_sharer_S4),
+    .x_coord            (sharer_x_S4),
+    .y_coord            (sharer_y_S4)
+);
 
 always @ *
 begin
@@ -1908,10 +1932,8 @@ begin
 `else      
             msg_send_dst_chipid_S4 = my_nodeid_chipid_S4;
 `endif      
-            msg_send_dst_x_S4 = {{(`MSG_SRC_X_WIDTH - `L2_OWNER_X_WIDTH){1'b0}}, 
-                                 l2_way_state_owner_S4_f[`L2_OWNER_X]}; 
-            msg_send_dst_y_S4 = {{(`MSG_SRC_Y_WIDTH - `L2_OWNER_Y_WIDTH){1'b0}},
-                                 l2_way_state_owner_S4_f[`L2_OWNER_Y]};
+            msg_send_dst_x_S4 = owner_x_S4; 
+            msg_send_dst_y_S4 = owner_y_S4;
         end
         msg_send_dst_fbits_S4 = `NOC_FBITS_L1;
     end
@@ -1937,8 +1959,8 @@ begin
         `endif
         begin
             msg_send_dst_chipid_S4 = my_nodeid_chipid_S4;
-            msg_send_dst_x_S4 = {{(`MSG_SRC_X_WIDTH - `L2_OWNER_X_WIDTH){1'b0}}, dir_sharer_S4[`L2_OWNER_X]}; 
-            msg_send_dst_y_S4 = {{(`MSG_SRC_Y_WIDTH - `L2_OWNER_Y_WIDTH){1'b0}}, dir_sharer_S4[`L2_OWNER_Y]};
+            msg_send_dst_x_S4 = sharer_x_S4; 
+            msg_send_dst_y_S4 = sharer_y_S4;
         end
         msg_send_dst_fbits_S4 = `NOC_FBITS_L1;
     end

--- a/piton/design/include/define.h.pyv
+++ b/piton/design/include/define.h.pyv
@@ -489,10 +489,10 @@ print "`define Y_TILES %d"   % Y_TILES;
 `define HOME_ID_ADDR_POS_LOW        `HOME_ID_WIDTH+5 : 6
 `define HOME_ID_ADDR_POS_MIDDLE     `HOME_ID_WIDTH+13 : 14
 `define HOME_ID_ADDR_POS_HIGH       `HOME_ID_WIDTH+23 : 24
-`define HOME_ID_X_POS_WIDTH         3
-`define HOME_ID_X_POS               2:0
-`define HOME_ID_Y_POS_WIDTH         3
-`define HOME_ID_Y_POS               5:3
+//`define HOME_ID_X_POS_WIDTH         3
+//`define HOME_ID_X_POS               2:0
+//`define HOME_ID_Y_POS_WIDTH         3
+//`define HOME_ID_Y_POS               5:3
 
 // Packet format for home id
 `define PACKET_HOME_ID_WIDTH        (`NOC_CHIPID_WIDTH+`NOC_X_WIDTH+`NOC_Y_WIDTH)

--- a/piton/design/include/l2.h.pyv
+++ b/piton/design/include/l2.h.pyv
@@ -229,11 +229,11 @@ print "`define L2_DIR_ARRAY_HEIGHT_LOG2     %d" % (math.log(L2_NUM_SETS*L2_WAYS,
 `define L2_SUBLINE_BITS         4
 
 `define L2_OWNER_BITS           6
-`define L2_OWNER_X_WIDTH        3
-`define L2_OWNER_Y_WIDTH        3
-`define L2_OWNER_XY             2:0
-`define L2_OWNER_X              2:0
-`define L2_OWNER_Y              5:3
+//`define L2_OWNER_X_WIDTH        3
+//`define L2_OWNER_Y_WIDTH        3
+//`define L2_OWNER_XY             2:0
+//`define L2_OWNER_X              2:0
+//`define L2_OWNER_Y              5:3
 
 
 

--- a/piton/tools/src/proto/common/rtl_setup.tcl
+++ b/piton/tools/src/proto/common/rtl_setup.tcl
@@ -231,6 +231,7 @@ set CHIP_RTL_IMPL_FILES [list \
     "${DV_ROOT}/design/chip/tile/common/rtl/valrdy_to_credit.v" \
     "${DV_ROOT}/design/chip/tile/common/rtl/credit_to_valrdy.v" \
     "${DV_ROOT}/design/chip/tile/common/rtl/flat_id_to_xy.v" \
+    "${DV_ROOT}/design/chip/tile/common/rtl/xy_to_flat_id.v" \
     "${DV_ROOT}/design/chip/tile/common/rtl/clk_gating_latch.v" \
     "${DV_ROOT}/design/chip/tile/common/rtl/test_stub_scan.v" \
     "${DV_ROOT}/design/chip/tile/common/rtl/synchronizer_asr.v" \


### PR DESCRIPTION
Previously, due to the fixed 3-bit field of x/y coordinates, we can not have more than 8 cores in one dimension. 

Now, x/y coordinates to flat_ID converter is used to enable more cores in one dimension. Although the owner field is still 6 bits wide, we can have the configuration like x=64 y=1 now.  