### PR TITLE
support non-cacheable off-chip requests for simulation 

### DIFF
--- a/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
+++ b/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
@@ -649,7 +649,7 @@ assign csm_noc1encoder_req_type = `L15_NOC1_REQTYPE_LD_REQUEST;
 assign csm_noc1encoder_req_mshrid = refill_req_ticket_buf[refill_req_buf_rd_ptr];
 assign csm_noc1encoder_req_address = refill_req_addr_buf[refill_req_buf_rd_ptr];
 assign csm_noc1encoder_req_non_cacheable = 1'b1;
-assign csm_noc1encoder_req_size = `PCX_SZ_16B; // use pcx def because noc1enc translate it to packet def
+assign csm_noc1encoder_req_size = `MSG_DATA_SIZE_16B; 
 
 /*
 // calculate (or look up ghid from address)

--- a/piton/design/chip/tile/l15/rtl/l15_pipeline.v.pyv
+++ b/piton/design/chip/tile/l15/rtl/l15_pipeline.v.pyv
@@ -641,6 +641,47 @@ begin
                     end
 
                 end
+                `MSG_TYPE_NC_LOAD_MEM_ACK:
+                begin
+                    predecode_icache_bit_s1 = predecode_mshr_read_control_s1[`L15_CONTROL_ICACHE];
+
+                    if (noc2decoder_l15_mshrid == `L15_MSHR_ID_LD)
+                        predecode_address_s1 = mshr_ld_address_array[noc2decoder_l15_threadid];
+                    else if (noc2decoder_l15_mshrid == `L15_MSHR_ID_ST)
+                        predecode_address_s1 = mshr_st_address_array[noc2decoder_l15_threadid];
+
+                    if (predecode_non_cacheable_s1)
+                    begin
+                        // must get into this condition
+                        if (predecode_icache_bit_s1)
+                            predecode_reqtype_s1 = `L15_REQTYPE_ACKDT_IFILL;
+                        else if (predecode_dcache_load_s1)
+                            predecode_reqtype_s1 = `L15_REQTYPE_ACKDT_LD_NC;
+                        else if (predecode_atomic_s1)
+                            predecode_reqtype_s1 = `L15_REQTYPE_ACK_ATOMIC;
+                        else
+                            predecode_reqtype_s1 = `L15_REQTYPE_IGNORE; // error case
+                    end
+                    else
+                    begin
+                            predecode_reqtype_s1 = `L15_REQTYPE_IGNORE; // error case
+                    end
+                end
+                `MSG_TYPE_NC_STORE_MEM_ACK:
+                begin
+                    predecode_icache_bit_s1 = predecode_mshr_read_control_s1[`L15_CONTROL_ICACHE];
+                    predecode_address_s1 = mshr_st_address_array[noc2decoder_l15_threadid];
+
+                    // one way to distinguish prefetch ack from write-through ack is the mshrid
+                    if (noc2decoder_l15_mshrid == `L15_MSHR_ID_ST)
+                        predecode_reqtype_s1 = `L15_REQTYPE_ACK_WRITETHROUGH;
+                    else
+                    begin
+                        predecode_reqtype_s1 = `L15_REQTYPE_ACK_PREFETCH;
+                        predecode_address_s1 = 0; // bug fix, address cannot be X's
+                    end
+
+                end
                 `MSG_TYPE_INTERRUPT:
                 begin
                     predecode_reqtype_s1 = `L15_REQTYPE_L2_INTERRUPT;

--- a/piton/design/chip/tile/l15/rtl/l15_pipeline.v.pyv
+++ b/piton/design/chip/tile/l15/rtl/l15_pipeline.v.pyv
@@ -582,7 +582,7 @@ begin
                                                                                                 predecode_address_plus0_s1;
                     end
                 end
-                `MSG_TYPE_DATA_ACK:
+                `MSG_TYPE_DATA_ACK, `MSG_TYPE_NC_LOAD_MEM_ACK:
                 begin
                     predecode_icache_bit_s1 = predecode_mshr_read_control_s1[`L15_CONTROL_ICACHE];
 
@@ -626,48 +626,7 @@ begin
                             predecode_reqtype_s1 = `L15_REQTYPE_IGNORE; // error case
                     end
                 end
-                `MSG_TYPE_NODATA_ACK:
-                begin
-                    predecode_icache_bit_s1 = predecode_mshr_read_control_s1[`L15_CONTROL_ICACHE];
-                    predecode_address_s1 = mshr_st_address_array[noc2decoder_l15_threadid];
-
-                    // one way to distinguish prefetch ack from write-through ack is the mshrid
-                    if (noc2decoder_l15_mshrid == `L15_MSHR_ID_ST)
-                        predecode_reqtype_s1 = `L15_REQTYPE_ACK_WRITETHROUGH;
-                    else
-                    begin
-                        predecode_reqtype_s1 = `L15_REQTYPE_ACK_PREFETCH;
-                        predecode_address_s1 = 0; // bug fix, address cannot be X's
-                    end
-
-                end
-                `MSG_TYPE_NC_LOAD_MEM_ACK:
-                begin
-                    predecode_icache_bit_s1 = predecode_mshr_read_control_s1[`L15_CONTROL_ICACHE];
-
-                    if (noc2decoder_l15_mshrid == `L15_MSHR_ID_LD)
-                        predecode_address_s1 = mshr_ld_address_array[noc2decoder_l15_threadid];
-                    else if (noc2decoder_l15_mshrid == `L15_MSHR_ID_ST)
-                        predecode_address_s1 = mshr_st_address_array[noc2decoder_l15_threadid];
-
-                    if (predecode_non_cacheable_s1)
-                    begin
-                        // must get into this condition
-                        if (predecode_icache_bit_s1)
-                            predecode_reqtype_s1 = `L15_REQTYPE_ACKDT_IFILL;
-                        else if (predecode_dcache_load_s1)
-                            predecode_reqtype_s1 = `L15_REQTYPE_ACKDT_LD_NC;
-                        else if (predecode_atomic_s1)
-                            predecode_reqtype_s1 = `L15_REQTYPE_ACK_ATOMIC;
-                        else
-                            predecode_reqtype_s1 = `L15_REQTYPE_IGNORE; // error case
-                    end
-                    else
-                    begin
-                            predecode_reqtype_s1 = `L15_REQTYPE_IGNORE; // error case
-                    end
-                end
-                `MSG_TYPE_NC_STORE_MEM_ACK:
+                `MSG_TYPE_NODATA_ACK, `MSG_TYPE_NC_STORE_MEM_ACK:
                 begin
                     predecode_icache_bit_s1 = predecode_mshr_read_control_s1[`L15_CONTROL_ICACHE];
                     predecode_address_s1 = mshr_st_address_array[noc2decoder_l15_threadid];

--- a/piton/design/chip/tile/l15/rtl/l15_pipeline.v.pyv
+++ b/piton/design/chip/tile/l15/rtl/l15_pipeline.v.pyv
@@ -2138,9 +2138,9 @@ begin
         end
     endcase
 
-    unshifted_write_mask_s1 =   (predecode_size_s1 == `PCX_SZ_1B) ? 16'b1000_0000_0000_0000 :
-                                (predecode_size_s1 == `PCX_SZ_2B) ? 16'b1100_0000_0000_0000 :
-                                (predecode_size_s1 == `PCX_SZ_4B) ? 16'b1111_0000_0000_0000 :
+    unshifted_write_mask_s1 =   (predecode_size_s1 == `MSG_DATA_SIZE_1B) ? 16'b1000_0000_0000_0000 :
+                                (predecode_size_s1 == `MSG_DATA_SIZE_2B) ? 16'b1100_0000_0000_0000 :
+                                (predecode_size_s1 == `MSG_DATA_SIZE_4B) ? 16'b1111_0000_0000_0000 :
                                                                     16'b1111_1111_0000_0000 ;
 
     write_mask_1B_s1 = unshifted_write_mask_s1 >> (pcxdecoder_l15_address & 4'b1111);
@@ -2152,23 +2152,27 @@ begin
     write_mask_16B_s1 = {16{1'b1}};
 
     case(predecode_size_s1)
-        `PCX_SZ_1B:
+        `MSG_DATA_SIZE_1B:
         begin
             write_mask_s1 = write_mask_1B_s1;
         end
-        `PCX_SZ_2B:
+        `MSG_DATA_SIZE_2B:
         begin
             write_mask_s1 = write_mask_2B_s1;
         end
-        `PCX_SZ_4B:
+        `MSG_DATA_SIZE_4B:
         begin
             write_mask_s1 = write_mask_4B_s1;
         end
-        `PCX_SZ_8B:
+        `MSG_DATA_SIZE_8B:
         begin
             write_mask_s1 = write_mask_8B_s1;
         end
-        `PCX_SZ_16B:
+        `MSG_DATA_SIZE_16B:
+        begin
+            write_mask_s1 = write_mask_16B_s1;
+        end
+        default:
         begin
             write_mask_s1 = write_mask_16B_s1;
         end
@@ -4074,10 +4078,10 @@ begin
     case (cpx_data_source_s3)
         `L15_CPX_SOURCE_LRSC_FLAG:
         begin
-            l15_cpxencoder_data_0[`L15_UNPARAM_63_0] = ((size_s3 == `PCX_SZ_4B) ?
+            l15_cpxencoder_data_0[`L15_UNPARAM_63_0] = ((size_s3 == `MSG_DATA_SIZE_4B) ?
                 {7'b0,(~tagcheck_lrsc_flag_s3),24'b0, 7'b0,(~tagcheck_lrsc_flag_s3),24'b0} :
                 {7'b0,(~tagcheck_lrsc_flag_s3),56'b0});
-            l15_cpxencoder_data_1[`L15_UNPARAM_63_0] = ((size_s3 == `PCX_SZ_4B) ?
+            l15_cpxencoder_data_1[`L15_UNPARAM_63_0] = ((size_s3 == `MSG_DATA_SIZE_4B) ?
                 {7'b0,(~tagcheck_lrsc_flag_s3),24'b0, 7'b0,(~tagcheck_lrsc_flag_s3),24'b0} :
                 {7'b0,(~tagcheck_lrsc_flag_s3),56'b0}); // write 0 on success
         end

--- a/piton/design/chip/tile/l15/rtl/noc1encoder.v
+++ b/piton/design/chip/tile/l15/rtl/noc1encoder.v
@@ -440,6 +440,9 @@ begin
       `PCX_SZ_16B:
          msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
    endcase
+   if (req_type == `L15_NOC1_REQTYPE_IFILL_REQUEST) begin
+        msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_64B;
+   end
 
    msg_options_2[`MSG_CACHE_TYPE_] = msg_cache_type;
    msg_options_2[`MSG_SUBLINE_VECTOR_] = msg_subline_vector;

--- a/piton/design/chip/tile/l15/rtl/noc1encoder.v
+++ b/piton/design/chip/tile/l15/rtl/noc1encoder.v
@@ -428,24 +428,27 @@ begin
    msg_options_2 = 0;
    msg_options_3 = 0;
 
-   case (msg_data_size)
-      `PCX_SZ_1B:
-         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_1B;
-      `PCX_SZ_2B:
-         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_2B;
-      `PCX_SZ_4B:
-         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_4B;
-      `PCX_SZ_8B:
-         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_8B;
-      `PCX_SZ_16B:
-         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
-   endcase
-`ifdef L2_SEND_NC_REQ
-   if (req_type == `L15_NOC1_REQTYPE_IFILL_REQUEST) begin
-        msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_64B;
-   end
-`endif
+//   case (msg_data_size)
+//      `PCX_SZ_1B:
+//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_1B;
+//      `PCX_SZ_2B:
+//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_2B;
+//      `PCX_SZ_4B:
+//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_4B;
+//      `PCX_SZ_8B:
+//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_8B;
+//      `PCX_SZ_16B:
+//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
+//   endcase
+//`ifdef L2_SEND_NC_REQ
+//    // Just for Sparc, should move to pcx_decoder in the end
+//   if (req_type == `L15_NOC1_REQTYPE_IFILL_REQUEST && msg_data_size != `PCX_SZ_4B) begin
+//       // Ariane core
+//        msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_32B;
+//   end
+//`endif
 
+   msg_options_2[`MSG_DATA_SIZE_] = msg_data_size;
    msg_options_2[`MSG_CACHE_TYPE_] = msg_cache_type;
    msg_options_2[`MSG_SUBLINE_VECTOR_] = msg_subline_vector;
 

--- a/piton/design/chip/tile/l15/rtl/noc1encoder.v
+++ b/piton/design/chip/tile/l15/rtl/noc1encoder.v
@@ -428,26 +428,6 @@ begin
    msg_options_2 = 0;
    msg_options_3 = 0;
 
-//   case (msg_data_size)
-//      `PCX_SZ_1B:
-//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_1B;
-//      `PCX_SZ_2B:
-//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_2B;
-//      `PCX_SZ_4B:
-//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_4B;
-//      `PCX_SZ_8B:
-//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_8B;
-//      `PCX_SZ_16B:
-//         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
-//   endcase
-//`ifdef L2_SEND_NC_REQ
-//    // Just for Sparc, should move to pcx_decoder in the end
-//   if (req_type == `L15_NOC1_REQTYPE_IFILL_REQUEST && msg_data_size != `PCX_SZ_4B) begin
-//       // Ariane core
-//        msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_32B;
-//   end
-//`endif
-
    msg_options_2[`MSG_DATA_SIZE_] = msg_data_size;
    msg_options_2[`MSG_CACHE_TYPE_] = msg_cache_type;
    msg_options_2[`MSG_SUBLINE_VECTOR_] = msg_subline_vector;

--- a/piton/design/chip/tile/l15/rtl/noc1encoder.v
+++ b/piton/design/chip/tile/l15/rtl/noc1encoder.v
@@ -440,9 +440,11 @@ begin
       `PCX_SZ_16B:
          msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
    endcase
+`ifdef L2_SEND_NC_REQ
    if (req_type == `L15_NOC1_REQTYPE_IFILL_REQUEST) begin
         msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_64B;
    end
+`endif
 
    msg_options_2[`MSG_CACHE_TYPE_] = msg_cache_type;
    msg_options_2[`MSG_SUBLINE_VECTOR_] = msg_subline_vector;

--- a/piton/design/chip/tile/l15/rtl/noc2decoder.v
+++ b/piton/design/chip/tile/l15/rtl/noc2decoder.v
@@ -120,10 +120,10 @@ begin
     // non-cacheable load data ack  -- 1-16B / 1-2 flit  sparc may send 16BNC-load
     // interrupt            -- 1 flit 
     noc2decoder_l15_data_0 = noc2_data[2*64 - 1 -: 64];
-    noc2decoder_l15_data_1 = (msg_len == 1) ? noc2_data[2*64 - 1 -: 64] : noc2_data[3*64 - 1 -: 64];
-    noc2decoder_l15_data_2 = (msg_len <= 2) ? noc2_data[2*64 - 1 -: 64] : noc2_data[4*64 - 1 -: 64];
-    noc2decoder_l15_data_3 = (msg_len == 1) ? noc2_data[2*64 - 1 -: 64] :
-                                    (msg_len == 2) ? noc2_data[3*64 - 1 -: 64] : noc2_data[5*64 - 1 -: 64];
+    noc2decoder_l15_data_1 = (msg_len == `MSG_LENGTH_WIDTH'd1) ? noc2_data[2*64 - 1 -: 64] : noc2_data[3*64 - 1 -: 64];
+    noc2decoder_l15_data_2 = (msg_len <= `MSG_LENGTH_WIDTH'd2) ? noc2_data[2*64 - 1 -: 64] : noc2_data[4*64 - 1 -: 64];
+    noc2decoder_l15_data_3 = (msg_len == `MSG_LENGTH_WIDTH'd1) ? noc2_data[2*64 - 1 -: 64] :
+                                    (msg_len == `MSG_LENGTH_WIDTH'd2) ? noc2_data[3*64 - 1 -: 64] : noc2_data[5*64 - 1 -: 64];
 
     noc2decoder_l15_src_homeid = 0;
     noc2decoder_l15_src_homeid[`PACKET_HOME_ID_Y_MASK] = noc2_data[`MSG_SRC_Y];

--- a/piton/design/chip/tile/l15/rtl/noc3encoder.v
+++ b/piton/design/chip/tile/l15/rtl/noc3encoder.v
@@ -238,10 +238,11 @@ begin
     msg_options_4 = 0;
 
     // trin: line coverage: 16B transaction apparently does not happen with the T1 core
-    if (msg_data_size == `PCX_SZ_16B)
-        msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
-    else
-        msg_options_2[`MSG_DATA_SIZE_] = msg_data_size;
+    msg_options_2[`MSG_DATA_SIZE_] = msg_data_size;
+    //if (msg_data_size == `PCX_SZ_16B)
+    //    msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
+    //else
+    //    msg_options_2[`MSG_DATA_SIZE_] = msg_data_size;
     msg_options_2[`MSG_CACHE_TYPE_] = msg_cache_type;
     msg_options_2[`MSG_SUBLINE_VECTOR_] = msg_subline_vector;
 
@@ -271,10 +272,10 @@ begin
             flit[`MSG_ADDR_] = address;
             flit[`MSG_OPTIONS_2_] = msg_options_2;
             // trin: line coverage: 16B transaction apparently does not happen with the T1 core
-            if (msg_data_size == `PCX_SZ_16B)
-                flit[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
-            else
-                flit[`MSG_DATA_SIZE_] = msg_data_size;
+            //if (msg_data_size == `PCX_SZ_16B)
+            //    flit[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
+            //else
+            //    flit[`MSG_DATA_SIZE_] = msg_data_size;
         end
         else if (flit_state == `NOC3_REQ_HEADER_3)
         begin

--- a/piton/design/chip/tile/l15/rtl/noc3encoder.v
+++ b/piton/design/chip/tile/l15/rtl/noc3encoder.v
@@ -239,10 +239,6 @@ begin
 
     // trin: line coverage: 16B transaction apparently does not happen with the T1 core
     msg_options_2[`MSG_DATA_SIZE_] = msg_data_size;
-    //if (msg_data_size == `PCX_SZ_16B)
-    //    msg_options_2[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
-    //else
-    //    msg_options_2[`MSG_DATA_SIZE_] = msg_data_size;
     msg_options_2[`MSG_CACHE_TYPE_] = msg_cache_type;
     msg_options_2[`MSG_SUBLINE_VECTOR_] = msg_subline_vector;
 
@@ -271,11 +267,6 @@ begin
         begin
             flit[`MSG_ADDR_] = address;
             flit[`MSG_OPTIONS_2_] = msg_options_2;
-            // trin: line coverage: 16B transaction apparently does not happen with the T1 core
-            //if (msg_data_size == `PCX_SZ_16B)
-            //    flit[`MSG_DATA_SIZE_] = `MSG_DATA_SIZE_16B;
-            //else
-            //    flit[`MSG_DATA_SIZE_] = msg_data_size;
         end
         else if (flit_state == `NOC3_REQ_HEADER_3)
         begin

--- a/piton/design/chip/tile/l15/rtl/pcx_decoder.v
+++ b/piton/design/chip/tile/l15/rtl/pcx_decoder.v
@@ -81,8 +81,8 @@ begin
       is_message_new <= is_message_new_next;
 end
 
-reg [2:0] pcxdecoder_l15_size_PCX_standard;
-reg [2:0] pcxdecoder_l15_size_PMesh_standard;
+reg [2:0] pcxdecoder_l15_size_pcx_standard;
+reg [2:0] pcxdecoder_l15_size_pmesh_standard;
 
 always @ *
 begin
@@ -100,7 +100,7 @@ begin
    pcxdecoder_l15_invalidate_cacheline = message[111];
    pcxdecoder_l15_blockinitstore = message[109];
    pcxdecoder_l15_l1rplway = message[`PCX_WY_HI:`PCX_WY_LO];
-   pcxdecoder_l15_size_PCX_standard = message[`PCX_SZ_HI:`PCX_SZ_LO];
+   pcxdecoder_l15_size_pcx_standard = message[`PCX_SZ_HI:`PCX_SZ_LO];
    pcxdecoder_l15_address = message[`PCX_AD_HI:`PCX_AD_LO]; // 40b
    pcxdecoder_l15_data = message[`PCX_DA_HI:`PCX_DA_LO];
    pcxdecoder_l15_data_next_entry = pcxbuf_pcxdecoder_data_buf1[`PCX_DA_HI:`PCX_DA_LO];
@@ -129,27 +129,27 @@ begin
 end
 
 always @(*) begin
-   case (pcxdecoder_l15_size_PCX_standard)
+   case (pcxdecoder_l15_size_pcx_standard)
       `PCX_SZ_1B:
-         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_1B;
+         pcxdecoder_l15_size_pmesh_standard = `MSG_DATA_SIZE_1B;
       `PCX_SZ_2B:
-         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_2B;
+         pcxdecoder_l15_size_pmesh_standard = `MSG_DATA_SIZE_2B;
       `PCX_SZ_4B:
-         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_4B;
+         pcxdecoder_l15_size_pmesh_standard = `MSG_DATA_SIZE_4B;
       `PCX_SZ_8B:
-         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_8B;
+         pcxdecoder_l15_size_pmesh_standard = `MSG_DATA_SIZE_8B;
       `PCX_SZ_16B:
-         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_16B;
+         pcxdecoder_l15_size_pmesh_standard = `MSG_DATA_SIZE_16B;
    endcase
 `ifdef L2_SEND_NC_REQ
    // Sparc sends both 4B and 32B non-cacheable ifill. 
    // Since we could not distinguish them, 
    // we set the data size to always be 32B for ifill
    if (pcxdecoder_l15_rqtype == `PCX_REQTYPE_IFILL && ~pcxdecoder_l15_invalidate_cacheline) begin
-        pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_32B;
+        pcxdecoder_l15_size_pmesh_standard = `MSG_DATA_SIZE_32B;
    end
 `endif
 
-    pcxdecoder_l15_size = pcxdecoder_l15_size_PMesh_standard;
+    pcxdecoder_l15_size = pcxdecoder_l15_size_pmesh_standard;
 end
 endmodule

--- a/piton/design/chip/tile/l15/rtl/pcx_decoder.v
+++ b/piton/design/chip/tile/l15/rtl/pcx_decoder.v
@@ -81,6 +81,9 @@ begin
       is_message_new <= is_message_new_next;
 end
 
+reg [2:0] pcxdecoder_l15_size_PCX_standard;
+reg [2:0] pcxdecoder_l15_size_PMesh_standard;
+
 always @ *
 begin
    pcxdecoder_l15_val = pcxbuf_pcxdecoder_valid && message[`PCX_VLD] && is_message_new;
@@ -97,7 +100,7 @@ begin
    pcxdecoder_l15_invalidate_cacheline = message[111];
    pcxdecoder_l15_blockinitstore = message[109];
    pcxdecoder_l15_l1rplway = message[`PCX_WY_HI:`PCX_WY_LO];
-   pcxdecoder_l15_size = message[`PCX_SZ_HI:`PCX_SZ_LO];
+   pcxdecoder_l15_size_PCX_standard = message[`PCX_SZ_HI:`PCX_SZ_LO];
    pcxdecoder_l15_address = message[`PCX_AD_HI:`PCX_AD_LO]; // 40b
    pcxdecoder_l15_data = message[`PCX_DA_HI:`PCX_DA_LO];
    pcxdecoder_l15_data_next_entry = pcxbuf_pcxdecoder_data_buf1[`PCX_DA_HI:`PCX_DA_LO];
@@ -123,5 +126,30 @@ begin
       pcxdecoder_l15_rqtype = `PCX_REQTYPE_AMO;
       pcxdecoder_l15_amo_op = `L15_AMO_OP_SWAP;
    end
+end
+
+always @(*) begin
+   case (pcxdecoder_l15_size_PCX_standard)
+      `PCX_SZ_1B:
+         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_1B;
+      `PCX_SZ_2B:
+         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_2B;
+      `PCX_SZ_4B:
+         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_4B;
+      `PCX_SZ_8B:
+         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_8B;
+      `PCX_SZ_16B:
+         pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_16B;
+   endcase
+`ifdef L2_SEND_NC_REQ
+   // Sparc sends both 4B and 32B non-cacheable ifill. 
+   // Since we could not distinguish them, 
+   // we set the data size to always be 32B for ifill
+   if (pcxdecoder_l15_rqtype == `PCX_REQTYPE_IFILL && ~pcxdecoder_l15_invalidate_cacheline) begin
+        pcxdecoder_l15_size_PMesh_standard = `MSG_DATA_SIZE_32B;
+   end
+`endif
+
+    pcxdecoder_l15_size = pcxdecoder_l15_size_PMesh_standard;
 end
 endmodule

--- a/piton/design/chip/tile/l15/rtl/pico_decoder.v
+++ b/piton/design/chip/tile/l15/rtl/pico_decoder.v
@@ -151,13 +151,13 @@ module pico_decoder(
 
                 case(pico_mem_wstrb)
 		            4'b1111: begin
-		                picodecoder_l15_size = `PCX_SZ_4B;
+		                picodecoder_l15_size = `MSG_DATA_SIZE_4B;
 		            end
 		            4'b1100, 4'b0011: begin
-		                picodecoder_l15_size = `PCX_SZ_2B;
+		                picodecoder_l15_size = `MSG_DATA_SIZE_2B;
 		            end
 		            4'b1000, 4'b0100, 4'b0010, 4'b0001: begin
-		                picodecoder_l15_size = `PCX_SZ_1B;
+		                picodecoder_l15_size = `MSG_DATA_SIZE_1B;
 		            end
 		            // this should never happen
 		            default: begin
@@ -169,7 +169,7 @@ module pico_decoder(
 	        else begin
 	            pico_wdata_flipped = 32'b0;
                 picodecoder_l15_rqtype = `LOAD_RQ;
-	            picodecoder_l15_size = `PCX_SZ_4B;
+	            picodecoder_l15_size = `MSG_DATA_SIZE_4B;
 	        end 
         end
         else begin

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1.v
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1.v
@@ -850,6 +850,7 @@ l2_pipe1_dpath dpath(
     .dir_data_sel_S4            (dir_data_sel_S4),
     .dir_data_S4                (dir_data_S4),
     .msg_send_type_S4           (msg_send_type),
+    .msg_send_length_S4         (msg_send_length),
     .my_nodeid_chipid_S4        (my_nodeid[`NOC_NODEID_CHIPID]),
     .my_nodeid_x_S4             (my_nodeid[`NOC_NODEID_X]),
     .my_nodeid_y_S4             (my_nodeid[`NOC_NODEID_Y]),

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1.v
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1.v
@@ -301,7 +301,7 @@ wire [`L2_MESI_BITS-1:0] state_mesi_S2;
 wire state_lru_en_S2;
 wire [`L2_LRU_OP_BITS-1:0] state_lru_op_S2;
 wire state_rb_en_S2;
-wire l2_ifill_S2;
+wire l2_ifill_32B_S2;
 wire [`L2_DATA_SUBLINE_WIDTH-1:0] l2_load_data_subline_S2;
 wire [`PHY_ADDR_WIDTH-1:0] addr_S2;
 wire l2_tag_hit_S2;
@@ -658,7 +658,7 @@ l2_pipe1_ctrl ctrl(
     .state_lru_op_S2            (state_lru_op_S2),
     .state_rb_en_S2             (state_rb_en_S2),
     .state_load_sdid_S2         (state_load_sdid_S2),
-    .l2_ifill_S2                (l2_ifill_S2),
+    .l2_ifill_32B_S2            (l2_ifill_32B_S2),
     .l2_load_data_subline_S2    (l2_load_data_subline_S2),
     .msg_data_ready_S2          (msg_data_ready),
     `ifndef NO_RTL_CSM
@@ -817,7 +817,7 @@ l2_pipe1_dpath dpath(
     .state_rb_en_S2             (state_rb_en_S2),
     .state_load_sdid_S2         (state_load_sdid_S2),
     .dir_op_S2                  (dir_op_S2),
-    .l2_ifill_S2                (l2_ifill_S2),
+    .l2_ifill_32B_S2            (l2_ifill_32B_S2),
     .l2_load_data_subline_S2    (l2_load_data_subline_S2),
     .valid_S2                   (valid_S2),
     .stall_S2                   (stall_S2),

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -2162,6 +2162,14 @@ begin
     && (cache_type_S2_f == `MSG_CACHE_TYPE_INS))
     begin
         l2_ifill_S2 = y;
+`ifdef L2_SEND_NC_REQ
+        // NC ifill is on 4B, and do not need 2 cycles to read out the data.
+        // So l2_ifill for it is "n"
+        if (msg_type_S2_f == `MSG_TYPE_NC_LOAD_REQ && data_size_S2_f != `MSG_DATA_SIZE_32B)
+        begin
+            l2_ifill_S2 = n;
+        end
+`endif
     end
     else
     begin
@@ -3484,22 +3492,53 @@ begin
 */
                 msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_1H2D;
                 msg_send_length_S4 = 2;
-                msg_send_data_size_S4 = data_size_S4_f;
+                // msg_send_data_size_S4 = data_size_S4_f;
                 msg_send_cache_type_S4 = cache_type_S4_f;
                 msg_send_mshrid_S4 = mshrid_S4;
             end
+`ifdef L2_SEND_NC_REQ
+            else if (msg_type_S4_f == `MSG_TYPE_NC_LOAD_REQ)
+            begin
+                if (cache_type_S4_f == `MSG_CACHE_TYPE_INS && data_size_S4_f == `MSG_DATA_SIZE_32B)
+                begin
+                    // Just for Sparc non-cacheable 32B ifill
+                    msg_send_length_S4 = 4;
+                    // msg_send_data_size_S4 = `MSG_DATA_SIZE_32B;
+                    msg_send_cache_type_S4 = cache_type_S4_f;
+                    msg_send_mshrid_S4 = mshrid_S4;
+                    if (l2_load_data_subline_S4_f == `L2_DATA_SUBLINE_0)
+                    begin
+                        msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_1H2D;
+                    end
+                    else
+                    begin
+                        msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_0H2D;
+                    end
+                end
+                else
+                begin
+                    // non-cacheable data load should be within 8B, but sparc sends 16B nc-load
+                    msg_send_mode_S4 = (data_size_S4_f == `MSG_DATA_SIZE_16B) ? `L2_P1_BUF_OUT_MODE_1H2D : `L2_P1_BUF_OUT_MODE_1H1D;
+                    msg_send_length_S4 = (data_size_S4_f == `MSG_DATA_SIZE_16B) ? 2 : 1;
+                    // msg_send_data_size_S4 = 1-8B;
+                    msg_send_cache_type_S4 = cache_type_S4_f;
+                    msg_send_mshrid_S4 = mshrid_S4;
+                end
+            end
+`endif
             else if (cache_type_S4_f == `MSG_CACHE_TYPE_DATA)
             begin
                 msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_1H2D;
                 msg_send_length_S4 = 2;
-                msg_send_data_size_S4 = `MSG_DATA_SIZE_16B;
+                // msg_send_data_size_S4 = `MSG_DATA_SIZE_16B;
                 msg_send_cache_type_S4 = cache_type_S4_f;
                 msg_send_mshrid_S4 = mshrid_S4;
             end
             else
             begin
+                // ifill ack
                 msg_send_length_S4 = 4;
-                msg_send_data_size_S4 = `MSG_DATA_SIZE_32B;
+                // msg_send_data_size_S4 = `MSG_DATA_SIZE_32B;
                 msg_send_cache_type_S4 = cache_type_S4_f;
                 msg_send_mshrid_S4 = mshrid_S4;
                 if (l2_load_data_subline_S4_f == `L2_DATA_SUBLINE_0)

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -3534,6 +3534,13 @@ begin
 `else
             msg_send_data_size_S4 = data_size_S4_f;
 `endif
+
+`ifndef NO_RTL_CSM
+            if (smc_miss_S4)
+            begin
+                msg_send_data_size_S4 = `MSG_DATA_SIZE_16B;
+            end
+`endif
             msg_send_cache_type_S4 = cache_type_S4_f;
             msg_send_mshrid_S4 = mshr_wr_index_in_S4;
         end

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -2842,7 +2842,11 @@ begin
                             begin
                                 //TODO
                                 //cs_S4 = {y,          `MSG_TYPE_NC_LOAD_REQ,    n,          `MSG_TYPE_ERROR};
-                                cs_S4 = {n,         y,          `MSG_TYPE_LOAD_MEM,    n,          `MSG_TYPE_ERROR};
+                                `ifdef L2_SEND_NC_REQ
+                                    cs_S4 = {n,         y,          `MSG_TYPE_NC_LOAD_REQ,    n,          `MSG_TYPE_ERROR};
+                                `else
+                                    cs_S4 = {n,         y,          `MSG_TYPE_LOAD_MEM,    n,          `MSG_TYPE_ERROR};
+                                `endif
                             end
                             else
                             begin
@@ -2859,7 +2863,11 @@ begin
                             begin
                                 //TODO
                                 //cs_S4 = {y,          `MSG_TYPE_NC_LOAD_REQ,    y,          `MSG_TYPE_STORE_MEM};
-                                cs_S4 = {n,         y,          `MSG_TYPE_LOAD_MEM,    y,          `MSG_TYPE_STORE_MEM};
+                                `ifdef L2_SEND_NC_REQ
+                                    cs_S4 = {n,         y,          `MSG_TYPE_NC_LOAD_REQ,    y,          `MSG_TYPE_STORE_MEM};
+                                `else
+                                    cs_S4 = {n,         y,          `MSG_TYPE_LOAD_MEM,    y,          `MSG_TYPE_STORE_MEM};
+                                `endif
                             end
                             else
                             begin
@@ -2904,7 +2912,11 @@ begin
                     begin
                         //TODO
                         //cs_S4 = {y,          `MSG_TYPE_NC_LOAD_REQ,    n,          `MSG_TYPE_ERROR};
-                        cs_S4 = {n,         y,          `MSG_TYPE_LOAD_MEM,    n,          `MSG_TYPE_ERROR};
+                        `ifdef L2_SEND_NC_REQ
+                            cs_S4 = {n,         y,          `MSG_TYPE_NC_LOAD_REQ,    n,          `MSG_TYPE_ERROR};
+                        `else
+                            cs_S4 = {n,         y,          `MSG_TYPE_LOAD_MEM,    n,          `MSG_TYPE_ERROR};
+                        `endif
                     end
                     else
                     begin

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -3465,7 +3465,7 @@ begin
         `MSG_TYPE_LOAD_FWD, `MSG_TYPE_STORE_FWD, `MSG_TYPE_INV_FWD:
         begin
             msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_3H0D;
-            msg_send_length_S4 = 2;
+            msg_send_length_S4 = `MSG_LENGTH_WIDTH'd2;
             msg_send_data_size_S4 = `MSG_DATA_SIZE_16B;
             msg_send_cache_type_S4 = l2_way_state_cache_type_S4;
             msg_send_mshrid_S4 = mshr_wr_index_in_S4;
@@ -3473,25 +3473,18 @@ begin
         `MSG_TYPE_NODATA_ACK:
         begin
             msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_1H0D;
-            msg_send_length_S4 = 0;
+            msg_send_length_S4 = `MSG_LENGTH_WIDTH'd0;
             msg_send_data_size_S4 = `MSG_DATA_SIZE_0B;
             msg_send_cache_type_S4 = cache_type_S4_f;
             msg_send_mshrid_S4 = mshrid_S4;
         end
         `MSG_TYPE_DATA_ACK:
         begin
+            // For DATA_ACK, data_size field is not used
             if (special_addr_type_S4_f)
             begin
-//TODO
-/*
-                msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_1H1D;
-                msg_send_length_S4 = 1;
-                msg_send_data_size_S4 = `MSG_DATA_SIZE_8B;
-                msg_send_cache_type_S4 = cache_type_S4_f;
-                msg_send_mshrid_S4 = mshrid_S4;
-*/
                 msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_1H2D;
-                msg_send_length_S4 = 2;
+                msg_send_length_S4 = `MSG_LENGTH_WIDTH'd2;
                 // msg_send_data_size_S4 = data_size_S4_f;
                 msg_send_cache_type_S4 = cache_type_S4_f;
                 msg_send_mshrid_S4 = mshrid_S4;
@@ -3502,7 +3495,7 @@ begin
                 if (cache_type_S4_f == `MSG_CACHE_TYPE_INS && data_size_S4_f == `MSG_DATA_SIZE_32B)
                 begin
                     // Just for Sparc non-cacheable 32B ifill
-                    msg_send_length_S4 = 4;
+                    msg_send_length_S4 = `MSG_LENGTH_WIDTH'd4;
                     // msg_send_data_size_S4 = `MSG_DATA_SIZE_32B;
                     msg_send_cache_type_S4 = cache_type_S4_f;
                     msg_send_mshrid_S4 = mshrid_S4;
@@ -3519,7 +3512,7 @@ begin
                 begin
                     // non-cacheable data load should be within 8B, but sparc sends 16B nc-load
                     msg_send_mode_S4 = (data_size_S4_f == `MSG_DATA_SIZE_16B) ? `L2_P1_BUF_OUT_MODE_1H2D : `L2_P1_BUF_OUT_MODE_1H1D;
-                    msg_send_length_S4 = (data_size_S4_f == `MSG_DATA_SIZE_16B) ? 2 : 1;
+                    msg_send_length_S4 = (data_size_S4_f == `MSG_DATA_SIZE_16B) ? `MSG_LENGTH_WIDTH'd2 : `MSG_LENGTH_WIDTH'd1;
                     // msg_send_data_size_S4 = 1-8B;
                     msg_send_cache_type_S4 = cache_type_S4_f;
                     msg_send_mshrid_S4 = mshrid_S4;
@@ -3529,7 +3522,7 @@ begin
             else if (cache_type_S4_f == `MSG_CACHE_TYPE_DATA)
             begin
                 msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_1H2D;
-                msg_send_length_S4 = 2;
+                msg_send_length_S4 = `MSG_LENGTH_WIDTH'd2;
                 // msg_send_data_size_S4 = `MSG_DATA_SIZE_16B;
                 msg_send_cache_type_S4 = cache_type_S4_f;
                 msg_send_mshrid_S4 = mshrid_S4;
@@ -3537,7 +3530,7 @@ begin
             else
             begin
                 // ifill ack
-                msg_send_length_S4 = 4;
+                msg_send_length_S4 = `MSG_LENGTH_WIDTH'd4;
                 // msg_send_data_size_S4 = `MSG_DATA_SIZE_32B;
                 msg_send_cache_type_S4 = cache_type_S4_f;
                 msg_send_mshrid_S4 = mshrid_S4;
@@ -3555,7 +3548,7 @@ begin
         `MSG_TYPE_LOAD_MEM:
         begin
             msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_3H0D;
-            msg_send_length_S4 = 2;
+            msg_send_length_S4 = `MSG_LENGTH_WIDTH'd2;
 `ifdef PITON_ASIC_RTL
             msg_send_data_size_S4 = `MSG_DATA_SIZE_64B;
 `else
@@ -3567,7 +3560,7 @@ begin
         `MSG_TYPE_NC_LOAD_REQ:
         begin
             msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_3H0D;
-            msg_send_length_S4 = 2;
+            msg_send_length_S4 = `MSG_LENGTH_WIDTH'd2;
 `ifdef PITON_ASIC_RTL
             msg_send_data_size_S4 = `MSG_DATA_SIZE_16B;
 `else
@@ -3587,7 +3580,7 @@ begin
         `MSG_TYPE_NC_STORE_REQ:
         begin
             msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_3H1D;
-            msg_send_length_S4 = 3;
+            msg_send_length_S4 = `MSG_LENGTH_WIDTH'd3;
             msg_send_data_size_S4 = data_size_S4_f;
             msg_send_cache_type_S4 = cache_type_S4_f;
             msg_send_mshrid_S4 = mshr_wr_index_in_S4;
@@ -3595,7 +3588,7 @@ begin
         `MSG_TYPE_INTERRUPT:
         begin
             msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_1H1D;
-            msg_send_length_S4 = 1;
+            msg_send_length_S4 = `MSG_LENGTH_WIDTH'd1;
             msg_send_data_size_S4 = data_size_S4_f;
             msg_send_cache_type_S4 = cache_type_S4_f;
             msg_send_mshrid_S4 = mshrid_S4;
@@ -3603,7 +3596,7 @@ begin
 
         `MSG_TYPE_STORE_MEM:
         begin
-            msg_send_length_S4 = 10;
+            msg_send_length_S4 = `MSG_LENGTH_WIDTH'd10;
 `ifdef PITON_ASIC_RTL
             msg_send_data_size_S4 = `MSG_DATA_SIZE_64B;
 `else
@@ -3623,7 +3616,7 @@ begin
         default:
         begin
             msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_0H0D;
-            msg_send_length_S4 = 0;
+            msg_send_length_S4 = `MSG_LENGTH_WIDTH'd0;
             msg_send_data_size_S4 = `MSG_DATA_SIZE_0B;
             msg_send_cache_type_S4 = `MSG_CACHE_TYPE_DATA;
             msg_send_mshrid_S4 = mshrid_S4;
@@ -3633,7 +3626,7 @@ begin
     else
     begin
         msg_send_mode_S4 = `L2_P1_BUF_OUT_MODE_0H0D;
-        msg_send_length_S4 = 0;
+        msg_send_length_S4 = `MSG_LENGTH_WIDTH'd0;
         msg_send_data_size_S4 = `MSG_DATA_SIZE_0B;
         msg_send_cache_type_S4 = `MSG_CACHE_TYPE_DATA;
         msg_send_mshrid_S4 = mshrid_S4;

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -243,7 +243,7 @@ module l2_pipe1_ctrl(
     output reg state_rb_en_S2,
 
     output reg [`L2_DATA_SUBLINE_WIDTH-1:0] l2_load_data_subline_S2,
-    output reg l2_ifill_S2,
+    output reg l2_ifill_32B_S2,
 
     output reg msg_data_ready_S2,
 
@@ -2156,24 +2156,24 @@ always @ *
 begin
     if (special_addr_type_S2)
     begin
-        l2_ifill_S2 = n;
+        l2_ifill_32B_S2 = n;
     end
     else if (valid_S2 && l2_tag_hit_S2 && data_clk_en_S2 && (data_rdw_en_S2 == rd) && ~l2_wb_S2
     && (cache_type_S2_f == `MSG_CACHE_TYPE_INS))
     begin
-        l2_ifill_S2 = y;
+        l2_ifill_32B_S2 = y;
 `ifdef L2_SEND_NC_REQ
         // NC ifill is on 4B, and do not need 2 cycles to read out the data.
         // So l2_ifill for it is "n"
         if (msg_type_S2_f == `MSG_TYPE_NC_LOAD_REQ && data_size_S2_f != `MSG_DATA_SIZE_32B)
         begin
-            l2_ifill_S2 = n;
+            l2_ifill_32B_S2 = n;
         end
 `endif
     end
     else
     begin
-        l2_ifill_S2 = n;
+        l2_ifill_32B_S2 = n;
     end
 end
 
@@ -2187,11 +2187,11 @@ begin
     begin
         l2_load_data_subline_S2_next = `L2_DATA_SUBLINE_0;
     end
-    else if (valid_S2 && !(stall_real_S2) && l2_ifill_S2 && (l2_load_data_subline_S2_f == `L2_DATA_SUBLINE_1))
+    else if (valid_S2 && !(stall_real_S2) && l2_ifill_32B_S2 && (l2_load_data_subline_S2_f == `L2_DATA_SUBLINE_1))
     begin
         l2_load_data_subline_S2_next = `L2_DATA_SUBLINE_0;
     end
-    else if (valid_S2 && !(stall_real_S2) && (l2_wb_S2 || l2_ifill_S2))
+    else if (valid_S2 && !(stall_real_S2) && (l2_wb_S2 || l2_ifill_32B_S2))
     begin
         l2_load_data_subline_S2_next = l2_load_data_subline_S2_f + 1;
     end
@@ -2215,7 +2215,7 @@ begin
     begin
         stall_load_S2 = (l2_load_data_subline_S2_f != `L2_DATA_SUBLINE_3);
     end
-    else if (l2_ifill_S2)
+    else if (l2_ifill_32B_S2)
     begin
         stall_load_S2 = (l2_load_data_subline_S2_f != `L2_DATA_SUBLINE_1);
     end

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_dpath.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_dpath.v.pyv
@@ -184,6 +184,7 @@ module l2_pipe1_dpath(
     input wire [`L2_OWNER_BITS-1:0] dir_sharer_counter_S4,
     input wire [`L2_OWNER_BITS-1:0] mshr_inv_counter_out_S4,
     input wire [`MSG_TYPE_WIDTH-1:0] msg_send_type_S4,
+    input wire [`MSG_LENGTH_WIDTH-1:0] msg_send_length_S4,
     input wire [`MSG_TYPE_WIDTH-1:0] msg_send_type_pre_S4,
     input wire state_wr_sel_S4,
     input wire [`MSG_TYPE_WIDTH-1:0] msg_type_S4,
@@ -2074,6 +2075,12 @@ begin
     begin
         msg_send_data_S4 = {2{msg_data_S4_f}}; 
     end
+`ifdef L2_SEND_NC_REQ
+    else if (msg_type_S4 == `MSG_TYPE_NC_LOAD_REQ && msg_send_type_S4 == `MSG_TYPE_DATA_ACK && msg_send_length_S4 == 1)
+    begin
+        msg_send_data_S4 = addr_S4[3] ? {2{data_data_ecc_S4[127:64]}} : {2{data_data_ecc_S4[63:0]}};
+    end
+`endif
     else    
     begin
         msg_send_data_S4 = data_data_ecc_S4;

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_dpath.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_dpath.v.pyv
@@ -153,7 +153,7 @@ module l2_pipe1_dpath(
     input wire state_lru_en_S2,
     input wire [`L2_LRU_OP_BITS-1:0] state_lru_op_S2,
     input wire state_rb_en_S2,
-    input wire l2_ifill_S2,
+    input wire l2_ifill_32B_S2,
     input wire [`L2_DATA_SUBLINE_WIDTH-1:0] l2_load_data_subline_S2,
     input wire valid_S2,
     input wire stall_S2,
@@ -869,7 +869,7 @@ begin
     begin
         data_addr_S2 = {addr_S2_f[`L2_TAG_INDEX],l2_way_sel_S2, l2_load_data_subline_S2};
     end
-    else if (l2_ifill_S2)
+    else if (l2_ifill_32B_S2)
     begin
         data_addr_S2 = {addr_S2_f[`L2_TAG_INDEX],l2_way_sel_S2, 
                         addr_S2_f[`L2_INS_SUBLINE], l2_load_data_subline_S2[0]};

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2.v
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2.v
@@ -208,6 +208,7 @@ wire [`L2_LRU_OP_BITS-1:0] state_lru_op_S2;
 wire state_rb_en_S2;
 wire dir_clr_en_S2;
 wire l2_load_64B_S2;
+wire l2_load_32B_S2;
 wire [`L2_DATA_SUBLINE_WIDTH-1:0] l2_load_data_subline_S2;
 //wire [`PHY_ADDR_WIDTH-1:0] addr_S2;
 wire l2_tag_hit_S2;
@@ -384,6 +385,7 @@ l2_pipe2_ctrl ctrl(
     .state_lru_op_S2            (state_lru_op_S2),
     .state_rb_en_S2             (state_rb_en_S2),
     .l2_load_64B_S2             (l2_load_64B_S2),
+    .l2_load_32B_S2             (l2_load_32B_S2),
     .l2_load_data_subline_S2    (l2_load_data_subline_S2),
     .msg_data_ready_S2          (msg_data_ready),
     `ifndef NO_RTL_CSM
@@ -452,6 +454,7 @@ l2_pipe2_dpath dpath(
     .state_rb_en_S2             (state_rb_en_S2),
     .dir_clr_en_S2              (dir_clr_en_S2),
     .l2_load_64B_S2             (l2_load_64B_S2),
+    .l2_load_32B_S2             (l2_load_32B_S2),
     .l2_load_data_subline_S2    (l2_load_data_subline_S2),
     .valid_S2                   (valid_S2),
     .stall_S2                   (stall_S2),

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
@@ -110,8 +110,9 @@ begin
         begin
             msg_data_state_next = msg_data_state_1F;
         end
-        else if (data_in[`MSG_LENGTH] == 4)
+        else if (data_in[`MSG_LENGTH] == 4 && (data_in[`MSG_TYPE] != `MSG_TYPE_WB_REQ))
         begin
+            // WB has 2 data flits
             msg_data_state_next = msg_data_state_4F;
         end
 `endif

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
@@ -104,10 +104,12 @@ begin
         begin
             msg_data_state_next = msg_data_state_0F;
         end
+`ifdef L2_SEND_NC_REQ
         else if (data_in[`MSG_LENGTH] == 1)
         begin
             msg_data_state_next = msg_data_state_1F;
         end
+`endif
         else    
         begin
             msg_data_state_next = msg_data_state_2F;
@@ -143,10 +145,12 @@ begin
                 msg_state_next = msg_state_data0;
             end
         end
+`ifdef L2_SEND_NC_REQ
         else if ((msg_state_f == msg_state_data0) && (msg_data_state_f == msg_data_state_1F))
         begin
             msg_state_next = msg_state_header0;
         end
+`endif
         else if ((msg_state_f == msg_state_data1) && (msg_data_state_f == msg_data_state_2F))
         begin
             msg_state_next = msg_state_header0;
@@ -426,20 +430,30 @@ begin
     data_buf_full = (data_buf_counter_f ==  `L2_P2_DATA_BUF_IN_SIZE);
 end
 
+`ifdef L2_SEND_NC_REQ
 // When receive 1 data flit, we store the same data flit in two slots in the buffer.
 // This is because we always read out 2 flits of data.
 wire extra_data_buf; 
 assign extra_data_buf = (msg_data_valid_in && msg_data_ready_in && msg_data_state_f == msg_data_state_1F) ? 1'b1 : 1'b0;
+`endif
 
 always @ *
 begin
     if ((msg_data_valid_in && msg_data_ready_in) && (msg_data_valid_out && msg_data_ready_out))
     begin
+`ifdef L2_SEND_NC_REQ
         data_buf_counter_next = data_buf_counter_f + 1 + extra_data_buf - `L2_P2_DATA_BUF_IN_FLITS;
+`else
+        data_buf_counter_next = data_buf_counter_f + 1 - `L2_P2_DATA_BUF_IN_FLITS;
+`endif
     end
     else if (msg_data_valid_in && msg_data_ready_in)
     begin 
+`ifdef L2_SEND_NC_REQ
         data_buf_counter_next = data_buf_counter_f + 1 + extra_data_buf;
+`else
+        data_buf_counter_next = data_buf_counter_f + 1;
+`endif
     end
     else if (msg_data_valid_out && msg_data_ready_out)
     begin 
@@ -490,7 +504,11 @@ begin
     end
     else if (msg_data_valid_in && msg_data_ready_in)
     begin
+`ifdef L2_SEND_NC_REQ
         data_wr_ptr_next = data_wr_ptr_f + 1 + extra_data_buf;
+`else
+        data_wr_ptr_next = data_wr_ptr_f + 1;
+`endif
     end
     else
     begin
@@ -507,7 +525,9 @@ end
 always @ *
 begin
     data_rd_ptr_plus1 = data_rd_ptr_f + 1;
+`ifdef L2_SEND_NC_REQ
     data_wr_ptr_plus1 = data_wr_ptr_f + 1;
+`endif
 end
 
 always @ *
@@ -535,17 +555,21 @@ for i in range(L2_P2_DATA_BUF_IN_SIZE):
     else if (msg_data_valid_in && msg_data_ready_in)
     begin
         data_buf_mem_f[data_wr_ptr_f] <= msg_data_in;
+`ifdef L2_SEND_NC_REQ
         if (extra_data_buf) begin
             data_buf_mem_f[data_wr_ptr_plus1] <= msg_data_in;
         end
         else begin
             data_buf_mem_f[data_wr_ptr_plus1] <=  data_buf_mem_f[data_wr_ptr_plus1];
         end
+`endif
     end
     else
     begin 
         data_buf_mem_f[data_wr_ptr_f] <=  data_buf_mem_f[data_wr_ptr_f];
+`ifdef L2_SEND_NC_REQ
         data_buf_mem_f[data_wr_ptr_plus1] <=  data_buf_mem_f[data_wr_ptr_plus1];
+`endif
     end
 end
 

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
@@ -41,6 +41,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 `include "l2.tmp.h"
 `include "define.tmp.h"
 
+`define LOCAL_STATE_WIDTH 4
+
 module l2_pipe2_buf_in(
 
     input wire clk,
@@ -65,29 +67,30 @@ L2_P2_HEADER_BUF_IN_SIZE = 4
 L2_P2_DATA_BUF_IN_SIZE = 16
 %>
 
-localparam msg_data_state_0F = 3'd0;
-localparam msg_data_state_1F = 3'd1; // NC load ack
-localparam msg_data_state_2F = 3'd2;
-localparam msg_data_state_4F = 3'd3;
-localparam msg_data_state_8F = 3'd4;
 
-localparam msg_state_header0 = 4'd0;
-localparam msg_state_header1 = 4'd1;
-localparam msg_state_header2 = 4'd2;
-localparam msg_state_data0 = 4'd3;
-localparam msg_state_data1 = 4'd4;
-localparam msg_state_data2 = 4'd5;
-localparam msg_state_data3 = 4'd6;
-localparam msg_state_data4 = 4'd7;
-localparam msg_state_data5 = 4'd8;
-localparam msg_state_data6 = 4'd9;
-localparam msg_state_data7 = 4'd10;
+localparam msg_data_state_0F = `LOCAL_STATE_WIDTH'd0;
+localparam msg_data_state_1F = `LOCAL_STATE_WIDTH'd1; // NC load ack
+localparam msg_data_state_2F = `LOCAL_STATE_WIDTH'd2;
+localparam msg_data_state_4F = `LOCAL_STATE_WIDTH'd3;
+localparam msg_data_state_8F = `LOCAL_STATE_WIDTH'd4;
 
-reg [3:0] msg_state_f;
-reg [3:0] msg_state_next;
+localparam msg_state_header0 = `LOCAL_STATE_WIDTH'd0;
+localparam msg_state_header1 = `LOCAL_STATE_WIDTH'd1;
+localparam msg_state_header2 = `LOCAL_STATE_WIDTH'd2;
+localparam msg_state_data0 = `LOCAL_STATE_WIDTH'd3;
+localparam msg_state_data1 = `LOCAL_STATE_WIDTH'd4;
+localparam msg_state_data2 = `LOCAL_STATE_WIDTH'd5;
+localparam msg_state_data3 = `LOCAL_STATE_WIDTH'd6;
+localparam msg_state_data4 = `LOCAL_STATE_WIDTH'd7;
+localparam msg_state_data5 = `LOCAL_STATE_WIDTH'd8;
+localparam msg_state_data6 = `LOCAL_STATE_WIDTH'd9;
+localparam msg_state_data7 = `LOCAL_STATE_WIDTH'd10;
 
-reg [2:0] msg_data_state_f;
-reg [2:0] msg_data_state_next;
+reg [`LOCAL_STATE_WIDTH-1:0] msg_state_f;
+reg [`LOCAL_STATE_WIDTH-1:0] msg_state_next;
+
+reg [`LOCAL_STATE_WIDTH-1:0] msg_data_state_f;
+reg [`LOCAL_STATE_WIDTH-1:0] msg_data_state_next;
 
 always @ *
 begin
@@ -97,20 +100,20 @@ begin
     end
     else if((msg_state_f == msg_state_header0) && valid_in)
     begin
-        if (data_in[`MSG_LENGTH] == 8)
+        if (data_in[`MSG_LENGTH] == `MSG_LENGTH_WIDTH'd8)
         begin
             msg_data_state_next = msg_data_state_8F;
         end
-        else if (data_in[`MSG_LENGTH] == 0)
+        else if (data_in[`MSG_LENGTH] == `MSG_LENGTH_WIDTH'd0)
         begin
             msg_data_state_next = msg_data_state_0F;
         end
 `ifdef L2_SEND_NC_REQ
-        else if (data_in[`MSG_LENGTH] == 1)
+        else if (data_in[`MSG_LENGTH] == `MSG_LENGTH_WIDTH'd1)
         begin
             msg_data_state_next = msg_data_state_1F;
         end
-        else if (data_in[`MSG_LENGTH] == 4 && (data_in[`MSG_TYPE] != `MSG_TYPE_WB_REQ))
+        else if (data_in[`MSG_LENGTH] == `MSG_LENGTH_WIDTH'd4 && (data_in[`MSG_TYPE] != `MSG_TYPE_WB_REQ))
         begin
             // WB has 2 data flits
             msg_data_state_next = msg_data_state_4F;
@@ -142,7 +145,7 @@ begin
     begin
         if ((msg_state_f == msg_state_header0) && (data_in[`MSG_TYPE] != `MSG_TYPE_WB_REQ))
         begin
-            if (data_in[`MSG_LENGTH] == 0)
+            if (data_in[`MSG_LENGTH] == `MSG_LENGTH_WIDTH'd0)
             begin
                 msg_state_next = msg_state_header0;
             end
@@ -173,7 +176,7 @@ begin
             end
             else
             begin
-                msg_state_next = msg_state_f + 3'd1;
+                msg_state_next = msg_state_f + `LOCAL_STATE_WIDTH'd1;
             end
         end
     end

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
@@ -66,6 +66,7 @@ L2_P2_DATA_BUF_IN_SIZE = 16
 %>
 
 localparam msg_data_state_0F = 2'd0;
+localparam msg_data_state_1F = 2'd3; // NC load ack
 localparam msg_data_state_2F = 2'd1;
 localparam msg_data_state_8F = 2'd2;
 
@@ -103,6 +104,10 @@ begin
         begin
             msg_data_state_next = msg_data_state_0F;
         end
+        else if (data_in[`MSG_LENGTH] == 1)
+        begin
+            msg_data_state_next = msg_data_state_1F;
+        end
         else    
         begin
             msg_data_state_next = msg_data_state_2F;
@@ -137,6 +142,10 @@ begin
             begin
                 msg_state_next = msg_state_data0;
             end
+        end
+        else if ((msg_state_f == msg_state_data0) && (msg_data_state_f == msg_data_state_1F))
+        begin
+            msg_state_next = msg_state_header0;
         end
         else if ((msg_state_f == msg_state_data1) && (msg_data_state_f == msg_data_state_2F))
         begin
@@ -409,6 +418,7 @@ reg [`L2_P2_DATA_BUF_IN_LOG_SIZE-1:0] data_rd_ptr_next;
 reg [`L2_P2_DATA_BUF_IN_LOG_SIZE-1:0] data_rd_ptr_plus1;
 reg [`L2_P2_DATA_BUF_IN_LOG_SIZE-1:0] data_wr_ptr_f;
 reg [`L2_P2_DATA_BUF_IN_LOG_SIZE-1:0] data_wr_ptr_next;
+reg [`L2_P2_DATA_BUF_IN_LOG_SIZE-1:0] data_wr_ptr_plus1;
 
 always @ *
 begin
@@ -416,15 +426,20 @@ begin
     data_buf_full = (data_buf_counter_f ==  `L2_P2_DATA_BUF_IN_SIZE);
 end
 
+// When receive 1 data flit, we store the same data flit in two slots in the buffer.
+// This is because we always read out 2 flits of data.
+wire extra_data_buf; 
+assign extra_data_buf = (msg_data_valid_in && msg_data_ready_in && msg_data_state_f == msg_data_state_1F) ? 1'b1 : 1'b0;
+
 always @ *
 begin
     if ((msg_data_valid_in && msg_data_ready_in) && (msg_data_valid_out && msg_data_ready_out))
     begin
-        data_buf_counter_next = data_buf_counter_f + 1 - `L2_P2_DATA_BUF_IN_FLITS;
+        data_buf_counter_next = data_buf_counter_f + 1 + extra_data_buf - `L2_P2_DATA_BUF_IN_FLITS;
     end
     else if (msg_data_valid_in && msg_data_ready_in)
     begin 
-        data_buf_counter_next = data_buf_counter_f + 1;
+        data_buf_counter_next = data_buf_counter_f + 1 + extra_data_buf;
     end
     else if (msg_data_valid_out && msg_data_ready_out)
     begin 
@@ -475,7 +490,7 @@ begin
     end
     else if (msg_data_valid_in && msg_data_ready_in)
     begin
-        data_wr_ptr_next = data_wr_ptr_f + 1;
+        data_wr_ptr_next = data_wr_ptr_f + 1 + extra_data_buf;
     end
     else
     begin
@@ -492,6 +507,7 @@ end
 always @ *
 begin
     data_rd_ptr_plus1 = data_rd_ptr_f + 1;
+    data_wr_ptr_plus1 = data_wr_ptr_f + 1;
 end
 
 always @ *
@@ -519,10 +535,17 @@ for i in range(L2_P2_DATA_BUF_IN_SIZE):
     else if (msg_data_valid_in && msg_data_ready_in)
     begin
         data_buf_mem_f[data_wr_ptr_f] <= msg_data_in;
+        if (extra_data_buf) begin
+            data_buf_mem_f[data_wr_ptr_plus1] <= msg_data_in;
+        end
+        else begin
+            data_buf_mem_f[data_wr_ptr_plus1] <=  data_buf_mem_f[data_wr_ptr_plus1];
+        end
     end
     else
     begin 
         data_buf_mem_f[data_wr_ptr_f] <=  data_buf_mem_f[data_wr_ptr_f];
+        data_buf_mem_f[data_wr_ptr_plus1] <=  data_buf_mem_f[data_wr_ptr_plus1];
     end
 end
 

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_buf_in.v.pyv
@@ -65,10 +65,11 @@ L2_P2_HEADER_BUF_IN_SIZE = 4
 L2_P2_DATA_BUF_IN_SIZE = 16
 %>
 
-localparam msg_data_state_0F = 2'd0;
-localparam msg_data_state_1F = 2'd3; // NC load ack
-localparam msg_data_state_2F = 2'd1;
-localparam msg_data_state_8F = 2'd2;
+localparam msg_data_state_0F = 3'd0;
+localparam msg_data_state_1F = 3'd1; // NC load ack
+localparam msg_data_state_2F = 3'd2;
+localparam msg_data_state_4F = 3'd3;
+localparam msg_data_state_8F = 3'd4;
 
 localparam msg_state_header0 = 4'd0;
 localparam msg_state_header1 = 4'd1;
@@ -85,8 +86,8 @@ localparam msg_state_data7 = 4'd10;
 reg [3:0] msg_state_f;
 reg [3:0] msg_state_next;
 
-reg [1:0] msg_data_state_f;
-reg [1:0] msg_data_state_next;
+reg [2:0] msg_data_state_f;
+reg [2:0] msg_data_state_next;
 
 always @ *
 begin
@@ -108,6 +109,10 @@ begin
         else if (data_in[`MSG_LENGTH] == 1)
         begin
             msg_data_state_next = msg_data_state_1F;
+        end
+        else if (data_in[`MSG_LENGTH] == 4)
+        begin
+            msg_data_state_next = msg_data_state_4F;
         end
 `endif
         else    
@@ -147,6 +152,10 @@ begin
         end
 `ifdef L2_SEND_NC_REQ
         else if ((msg_state_f == msg_state_data0) && (msg_data_state_f == msg_data_state_1F))
+        begin
+            msg_state_next = msg_state_header0;
+        end
+        else if ((msg_state_f == msg_state_data3) && (msg_data_state_f == msg_data_state_4F))
         begin
             msg_state_next = msg_state_header0;
         end

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_ctrl.v.pyv
@@ -974,7 +974,8 @@ assign state_rb_en_S2 = n;
 
 always @ *
 begin
-    if (msg_type_S2_f == `MSG_TYPE_LOAD_MEM_ACK)
+    if ((msg_type_S2_f == `MSG_TYPE_LOAD_MEM_ACK)
+        || (msg_type_S2_f == `MSG_TYPE_NC_LOAD_MEM_ACK && msg_length_S2_f == 8))
     begin
         l2_load_64B_S2 = y;
     end

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_ctrl.v.pyv
@@ -975,7 +975,10 @@ assign state_rb_en_S2 = n;
 always @ *
 begin
     if ((msg_type_S2_f == `MSG_TYPE_LOAD_MEM_ACK)
-        || (msg_type_S2_f == `MSG_TYPE_NC_LOAD_MEM_ACK && msg_length_S2_f == 8))
+`ifdef L2_SEND_NC_REQ
+        || (msg_type_S2_f == `MSG_TYPE_NC_LOAD_MEM_ACK && msg_length_S2_f == 8)
+`endif
+    )
     begin
         l2_load_64B_S2 = y;
     end

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_ctrl.v.pyv
@@ -161,6 +161,7 @@ module l2_pipe2_ctrl(
     output wire state_rb_en_S2,
 
     output reg l2_load_64B_S2, 
+    output reg l2_load_32B_S2, 
     output reg [`L2_DATA_SUBLINE_WIDTH-1:0] l2_load_data_subline_S2,
 
     output reg msg_data_ready_S2,
@@ -974,17 +975,22 @@ assign state_rb_en_S2 = n;
 
 always @ *
 begin
-    if ((msg_type_S2_f == `MSG_TYPE_LOAD_MEM_ACK)
-`ifdef L2_SEND_NC_REQ
-        || (msg_type_S2_f == `MSG_TYPE_NC_LOAD_MEM_ACK && msg_length_S2_f == 8)
-`endif
-    )
+    if (msg_type_S2_f == `MSG_TYPE_LOAD_MEM_ACK)
     begin
         l2_load_64B_S2 = y;
+        l2_load_32B_S2 = n;
     end
+`ifdef L2_SEND_NC_REQ
+    else if (msg_type_S2_f == `MSG_TYPE_NC_LOAD_MEM_ACK && msg_length_S2_f == 4)
+    begin
+        l2_load_64B_S2 = n;
+        l2_load_32B_S2 = y;
+    end
+`endif
     else    
     begin
         l2_load_64B_S2 = n;
+        l2_load_32B_S2 = n;
     end
 end
 
@@ -997,10 +1003,21 @@ begin
     begin
         l2_load_data_subline_S2_next = `L2_DATA_SUBLINE_0;
     end
+`ifdef L2_SEND_NC_REQ
+    else if (valid_S2 && !stall_real_S2 && l2_load_32B_S2 && (l2_load_data_subline_S2_f == `L2_DATA_SUBLINE_1))
+    begin
+        l2_load_data_subline_S2_next = `L2_DATA_SUBLINE_0;
+    end
+    else if (valid_S2 && !stall_real_S2 && (l2_load_64B_S2 || l2_load_32B_S2))
+    begin
+        l2_load_data_subline_S2_next = l2_load_data_subline_S2_f + 1;
+    end
+`else
     else if (valid_S2 && !stall_real_S2 && l2_load_64B_S2)
     begin
         l2_load_data_subline_S2_next = l2_load_data_subline_S2_f + 1;
     end
+`endif
     else
     begin
         l2_load_data_subline_S2_next = l2_load_data_subline_S2_f;
@@ -1019,6 +1036,12 @@ begin
     begin
         stall_load_S2 = (l2_load_data_subline_S2_f != `L2_DATA_SUBLINE_3);
     end
+`ifdef L2_SEND_NC_REQ
+    else if (l2_load_32B_S2)
+    begin
+        stall_load_S2 = (l2_load_data_subline_S2_f != `L2_DATA_SUBLINE_1);
+    end
+`endif
     else
     begin
         stall_load_S2 = n;

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_dpath.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_dpath.v.pyv
@@ -113,6 +113,7 @@ module l2_pipe2_dpath(
     input wire dir_clr_en_S2,
    
     input wire l2_load_64B_S2, 
+    input wire l2_load_32B_S2, 
     input wire [`L2_DATA_SUBLINE_WIDTH-1:0] l2_load_data_subline_S2,
  
     input wire valid_S2,
@@ -541,6 +542,13 @@ begin
     begin
         data_addr_S2 = {addr_S2_f[`L2_TAG_INDEX],l2_way_sel_S2, l2_load_data_subline_S2};
     end
+`ifdef L2_SEND_NC_REQ
+    else if (l2_load_32B_S2)
+    begin
+        data_addr_S2 = {addr_S2_f[`L2_TAG_INDEX],l2_way_sel_S2, 
+                        addr_S2_f[`L2_INS_SUBLINE], l2_load_data_subline_S2[0]};
+    end
+`endif
     else
     begin
         data_addr_S2 = {addr_S2_f[`L2_TAG_INDEX],l2_way_sel_S2, addr_S2_f[`L2_DATA_SUBLINE]};

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_dpath.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_dpath.v.pyv
@@ -191,8 +191,8 @@ always @ *
 begin
     if (msg_from_mshr_S1)
     begin
-        addr_S1 = {mshr_addr_S1[`L2_TAG], mshr_addr_S1[`L2_TAG_INDEX],
-                   msg_subline_id_S1, mshr_addr_S1[`L2_DATA_OFFSET]};
+        addr_S1 = (msg_type_S1 == `MSG_TYPE_NC_LOAD_MEM_ACK) ? mshr_addr_S1 :
+            {mshr_addr_S1[`L2_TAG], mshr_addr_S1[`L2_TAG_INDEX], msg_subline_id_S1, mshr_addr_S1[`L2_DATA_OFFSET]};
         src_chipid_S1 = mshr_src_chipid_S1;
         src_x_S1 = mshr_src_x_S1;   
         src_y_S1 = mshr_src_y_S1;   

--- a/piton/design/chip/tile/l2/rtl/l2_pipe2_dpath.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe2_dpath.v.pyv
@@ -191,8 +191,13 @@ always @ *
 begin
     if (msg_from_mshr_S1)
     begin
+`ifdef L2_SEND_NC_REQ
         addr_S1 = (msg_type_S1 == `MSG_TYPE_NC_LOAD_MEM_ACK) ? mshr_addr_S1 :
             {mshr_addr_S1[`L2_TAG], mshr_addr_S1[`L2_TAG_INDEX], msg_subline_id_S1, mshr_addr_S1[`L2_DATA_OFFSET]};
+`else
+        addr_S1 = {mshr_addr_S1[`L2_TAG], mshr_addr_S1[`L2_TAG_INDEX],
+                         msg_subline_id_S1, mshr_addr_S1[`L2_DATA_OFFSET]};
+`endif // L2_SEND_NC_REQ
         src_chipid_S1 = mshr_src_chipid_S1;
         src_x_S1 = mshr_src_x_S1;   
         src_y_S1 = mshr_src_y_S1;   

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -942,14 +942,14 @@ if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_ariane_core
                         l15_transducer_inval_way,
                         l15_transducer_blockinitstore };
 
-    wire [2:0] transducer_l15_size_PCX_standard;
+    wire [2:0] transducer_l15_size_pcx_standard;
     // see serpent_cache_pkg.sv for definition of the packed struct type "l15_req_t",
     // note that the constants defined in l15.tmp.h and serpent_cache_pkg.sv need to coincide!
     assign { transducer_l15_val,
              transducer_l15_req_ack,
              transducer_l15_rqtype,
              transducer_l15_nc,
-             transducer_l15_size_PCX_standard,
+             transducer_l15_size_pcx_standard,
              transducer_l15_threadid,
              transducer_l15_prefetch,
              transducer_l15_invalidate_cacheline,
@@ -964,11 +964,11 @@ if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_ariane_core
 
     // Could remove this converter after Ariane is changed to send the 
     // PMesh standard data size
-    assign transducer_l15_size = (transducer_l15_size_PCX_standard == `PCX_SZ_1B) ? `MSG_DATA_SIZE_1B :
-                                    (transducer_l15_size_PCX_standard == `PCX_SZ_2B) ? `MSG_DATA_SIZE_2B : 
-                                    (transducer_l15_size_PCX_standard == `PCX_SZ_4B) ? `MSG_DATA_SIZE_4B : 
-                                    (transducer_l15_size_PCX_standard == `PCX_SZ_8B) ? `MSG_DATA_SIZE_8B : 
-                                    (transducer_l15_size_PCX_standard == `PCX_SZ_16B && 
+    assign transducer_l15_size = (transducer_l15_size_pcx_standard == `PCX_SZ_1B) ? `MSG_DATA_SIZE_1B :
+                                    (transducer_l15_size_pcx_standard == `PCX_SZ_2B) ? `MSG_DATA_SIZE_2B : 
+                                    (transducer_l15_size_pcx_standard == `PCX_SZ_4B) ? `MSG_DATA_SIZE_4B : 
+                                    (transducer_l15_size_pcx_standard == `PCX_SZ_8B) ? `MSG_DATA_SIZE_8B : 
+                                    (transducer_l15_size_pcx_standard == `PCX_SZ_16B && 
                                      transducer_l15_rqtype == `PCX_REQTYPE_IFILL && 
                                     ~transducer_l15_invalidate_cacheline) ? `MSG_DATA_SIZE_32B : `MSG_DATA_SIZE_16B; 
 

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -942,13 +942,14 @@ if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_ariane_core
                         l15_transducer_inval_way,
                         l15_transducer_blockinitstore };
 
+    wire [2:0] transducer_l15_size_PCX_standard;
     // see serpent_cache_pkg.sv for definition of the packed struct type "l15_req_t",
     // note that the constants defined in l15.tmp.h and serpent_cache_pkg.sv need to coincide!
     assign { transducer_l15_val,
              transducer_l15_req_ack,
              transducer_l15_rqtype,
              transducer_l15_nc,
-             transducer_l15_size,
+             transducer_l15_size_PCX_standard,
              transducer_l15_threadid,
              transducer_l15_prefetch,
              transducer_l15_invalidate_cacheline,
@@ -960,6 +961,16 @@ if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_ariane_core
              transducer_l15_data_next_entry,
              transducer_l15_csm_data,
              transducer_l15_amo_op} = l15_req;
+
+    // Could remove this converter after Ariane is changed to send the 
+    // PMesh standard data size
+    assign transducer_l15_size = (transducer_l15_size_PCX_standard == `PCX_SZ_1B) ? `MSG_DATA_SIZE_1B :
+                                    (transducer_l15_size_PCX_standard == `PCX_SZ_2B) ? `MSG_DATA_SIZE_2B : 
+                                    (transducer_l15_size_PCX_standard == `PCX_SZ_4B) ? `MSG_DATA_SIZE_4B : 
+                                    (transducer_l15_size_PCX_standard == `PCX_SZ_8B) ? `MSG_DATA_SIZE_8B : 
+                                    (transducer_l15_size_PCX_standard == `PCX_SZ_16B && 
+                                     transducer_l15_rqtype == `PCX_REQTYPE_IFILL && 
+                                    ~transducer_l15_invalidate_cacheline) ? `MSG_DATA_SIZE_32B : `MSG_DATA_SIZE_16B; 
 
     wire [63:0] ariane_bootaddr;
 

--- a/piton/design/chipset/noc_axilite_bridge/rtl/noc_axilite_bridge.v
+++ b/piton/design/chipset/noc_axilite_bridge/rtl/noc_axilite_bridge.v
@@ -439,7 +439,7 @@ localparam STORE_ACK = 1'd1;
     assign r_resp_buf_header0_next[`MSG_DST_FBITS]  = r_req_buf_header2_f[`MSG_SRC_FBITS_]; //TODO check this...
     assign r_resp_buf_header0_next[`MSG_LENGTH]     = (r_req_buf_header0_f[`MSG_TYPE] == `MSG_TYPE_NC_LOAD_REQ &&
                                                        r_req_buf_header1_f[`MSG_DATA_SIZE_] <= `MSG_DATA_SIZE_8B) ? `MSG_LENGTH_WIDTH'd1 :
-                                                       `MSG_LENGTH_WIDTH'd8; //none loads always return 8 words // TODO
+                                                       `MSG_LENGTH_WIDTH'd8; //loads return 8(cacheable) or 1(nc) words 
     assign r_resp_buf_header0_next[`MSG_TYPE]       = (r_req_buf_header0_f[`MSG_TYPE] == `MSG_TYPE_NC_LOAD_REQ) ? `MSG_TYPE_NC_LOAD_MEM_ACK :
                                                       (r_req_buf_header0_f[`MSG_TYPE] == `MSG_TYPE_LOAD_MEM) ? `MSG_TYPE_LOAD_MEM_ACK :
                                                       `MSG_TYPE_WIDTH'dx;

--- a/piton/design/chipset/noc_axilite_bridge/rtl/noc_axilite_bridge.v
+++ b/piton/design/chipset/noc_axilite_bridge/rtl/noc_axilite_bridge.v
@@ -437,7 +437,9 @@ localparam STORE_ACK = 1'd1;
     assign r_resp_buf_header0_next[`MSG_DST_X]      = r_req_buf_header2_f[`MSG_SRC_X_];
     assign r_resp_buf_header0_next[`MSG_DST_Y]      = r_req_buf_header2_f[`MSG_SRC_Y_];
     assign r_resp_buf_header0_next[`MSG_DST_FBITS]  = r_req_buf_header2_f[`MSG_SRC_FBITS_]; //TODO check this...
-    assign r_resp_buf_header0_next[`MSG_LENGTH]     = `MSG_LENGTH_WIDTH'd8; //none loads always return 8 words // TODO
+    assign r_resp_buf_header0_next[`MSG_LENGTH]     = (r_req_buf_header0_f[`MSG_TYPE] == `MSG_TYPE_NC_LOAD_REQ &&
+                                                       r_req_buf_header1_f[`MSG_DATA_SIZE_] <= `MSG_DATA_SIZE_8B) ? `MSG_LENGTH_WIDTH'd1 :
+                                                       `MSG_LENGTH_WIDTH'd8; //none loads always return 8 words // TODO
     assign r_resp_buf_header0_next[`MSG_TYPE]       = (r_req_buf_header0_f[`MSG_TYPE] == `MSG_TYPE_NC_LOAD_REQ) ? `MSG_TYPE_NC_LOAD_MEM_ACK :
                                                       (r_req_buf_header0_f[`MSG_TYPE] == `MSG_TYPE_LOAD_MEM) ? `MSG_TYPE_LOAD_MEM_ACK :
                                                       `MSG_TYPE_WIDTH'dx;

--- a/piton/verif/env/common/fake_mem_ctrl.v
+++ b/piton/verif/env/common/fake_mem_ctrl.v
@@ -320,7 +320,7 @@ begin
         end
         `MSG_TYPE_NC_LOAD_REQ:
         begin
-            $display("WooLaLa NC load, size is %h, address is %h", msg_data_size, msg_addr);
+            $display("Non-cacheable load request, size: %h, address: %h", msg_data_size, msg_addr);
             msg_send_type = `MSG_TYPE_NC_LOAD_MEM_ACK;
             case(msg_data_size)
             `MSG_DATA_SIZE_1B: 
@@ -462,7 +462,7 @@ begin
         end
         `MSG_TYPE_NC_STORE_REQ:
         begin
-            $display("WooLaLa NC store, size is %h, address is %h", msg_data_size, msg_addr);
+            $display("Non-cacheable store request, size: %h, address: %h", msg_data_size, msg_addr);
             msg_send_type = `MSG_TYPE_NC_STORE_MEM_ACK;
             msg_send_length = 8'd0;
             case(msg_data_size)

--- a/piton/verif/env/manycore/cmp_l15_messages_mon.v.pyv
+++ b/piton/verif/env/manycore/cmp_l15_messages_mon.v.pyv
@@ -458,6 +458,10 @@ begin
             noc2 = "MSG_TYPE_NODATA_ACK";
         `MSG_TYPE_DATA_ACK:
             noc2 = "MSG_TYPE_DATA_ACK";
+        `MSG_TYPE_NC_LOAD_MEM_ACK:
+            noc2 = "MSG_TYPE_NC_LOAD_MEM_ACK";
+        `MSG_TYPE_NC_STORE_MEM_ACK:
+            noc2 = "MSG_TYPE_NC_STORE_MEM_ACK";
         `MSG_TYPE_INTERRUPT:
             noc2 = "MSG_TYPE_L2_INTERRUPT";
         default:

--- a/piton/verif/env/manycore/l2_mon.v.pyv
+++ b/piton/verif/env/manycore/l2_mon.v.pyv
@@ -681,6 +681,31 @@ begin
         `MSG_TYPE_INTERRUPT             : $write("       int     ");
         `MSG_TYPE_L2_LINE_FLUSH_REQ     : $write("   line_flush  ");
         `MSG_TYPE_L2_DIS_FLUSH_REQ      : $write("    dis_flush  ");
+        `MSG_TYPE_LR_REQ                : $write("    lr_req     ");
+        `MSG_TYPE_AMO_ADD_REQ           : $write("  amo_add_req  ");
+        `MSG_TYPE_AMO_AND_REQ           : $write("  amo_and_req  ");
+        `MSG_TYPE_AMO_OR_REQ            : $write("  amo_or_req   ");
+        `MSG_TYPE_AMO_XOR_REQ           : $write("  amo_xor_req  ");
+        `MSG_TYPE_AMO_MAX_REQ           : $write("  amo_max_req  ");
+        `MSG_TYPE_AMO_MAXU_REQ          : $write("  amo_maxu_req ");
+        `MSG_TYPE_AMO_MIN_REQ           : $write("  amo_min_req  ");
+        `MSG_TYPE_AMO_MINU_REQ          : $write("  amo_minu_req ");
+        `MSG_TYPE_AMO_ADD_P1_REQ        : $write("  amo_add_p1   ");
+        `MSG_TYPE_AMO_AND_P1_REQ        : $write("  amo_and_p1   ");
+        `MSG_TYPE_AMO_OR_P1_REQ         : $write("  amo_or_p1    ");
+        `MSG_TYPE_AMO_XOR_P1_REQ        : $write("  amo_xor_p1   ");
+        `MSG_TYPE_AMO_MAX_P1_REQ        : $write("  amo_max_p1   ");
+        `MSG_TYPE_AMO_MAXU_P1_REQ       : $write("  amo_maxu_p1  ");
+        `MSG_TYPE_AMO_MIN_P1_REQ        : $write("  amo_min_p1   ");
+        `MSG_TYPE_AMO_MINU_P1_REQ       : $write("  amo_minu_p1  ");
+        `MSG_TYPE_AMO_ADD_P2_REQ        : $write("  amo_add_p2   ");
+        `MSG_TYPE_AMO_AND_P2_REQ        : $write("  amo_and_p2   ");
+        `MSG_TYPE_AMO_OR_P2_REQ         : $write("  amo_or_p2    ");
+        `MSG_TYPE_AMO_XOR_P2_REQ        : $write("  amo_xor_p2   ");
+        `MSG_TYPE_AMO_MAX_P2_REQ        : $write("  amo_max_p2   ");
+        `MSG_TYPE_AMO_MAXU_P2_REQ       : $write("  amo_maxu_p2  ");
+        `MSG_TYPE_AMO_MIN_P2_REQ        : $write("  amo_min_p2   ");
+        `MSG_TYPE_AMO_MINU_P2_REQ       : $write("  amo_minu_p2  ");
         default                         : $write("      undef    ");
     endcase
 end


### PR DESCRIPTION
L2 supports 1B/2B/4B/6B/16B/64B NC_LOAD_REQ, and 1B/2B/4B/8B NC_STORE_REQ.
Use -config_rtl=L2_SEND_NC_REQ to enable this. 

Changes for the chipset response logic is still in progress.    