### PR TITLE
Include device-tree-compiler package

### DIFF
--- a/piton/ariane_setup.sh
+++ b/piton/ariane_setup.sh
@@ -37,7 +37,8 @@
 #          default-jdk \
 #          zlib1g-dev \
 #          valgrind \
-#          csh
+#          csh \
+#          device-tree-compiler
 
 
 echo


### PR DESCRIPTION
Include device-tree-compiler package, sims fails to build without device-tree-compiler installed with error: dtc : command not found