### PR TITLE
Tile type and ISA cleanup

### DIFF
--- a/piton/design/chip/rtl/chip.v.pyv
+++ b/piton/design/chip/rtl/chip.v.pyv
@@ -1109,18 +1109,21 @@ module chip(
             currenttile = currenttile.replace("COREIDY", "8'd" + repr(j));
             currenttile = currenttile.replace("out_", "tile_%d_%d_out_" % (j,i));
             currenttile = currenttile.replace("_FLAT_ID_", repr(flatid));
+            currenttype = "`SPARC_TILE"
 
             if (PITON_PICO_HET):
                 if (flatid % 2) == 0:
-                    currenttile = currenttile.replace("TYPE_OF_TILE", "`SPARC_TILE")
+                    currenttype = "`SPARC_TILE"
                 else:
-                    currenttile = currenttile.replace("TYPE_OF_TILE", "`PICORV32_TILE")
+                    currenttype = "`PICORV32_TILE"
             elif (PITON_PICO):
-                currenttile = currenttile.replace("TYPE_OF_TILE", "`PICORV32_TILE")
+                currenttype = "`PICORV32_TILE"
             elif (PITON_ARIANE):
-                currenttile = currenttile.replace("TYPE_OF_TILE", "`ARIANE_RV64_TILE")
+                currenttype = "`ARIANE_RV64_TILE"
             else:
-                currenttile = currenttile.replace("TYPE_OF_TILE", "`SPARC_TILE")
+                currenttype = "`SPARC_TILE"
+
+            currenttile = currenttile.replace("TYPE_OF_TILE", currenttype)
 
             if (NETWORK_CONFIG == "xbar_config"):
                 currenttile = currenttile.replace("in_", "xbar_%d_out_" % i);

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -680,6 +680,7 @@ NIB_SIZE = pow(2, NIB_SIZE_LOG2)
 ///////////////////////
 generate
 if (TILE_TYPE == `SPARC_TILE) begin : g_sparc_core
+`ifdef PITON_OST1
     ////////////////
     // SPARC Core //
     ////////////////
@@ -818,11 +819,12 @@ if (TILE_TYPE == `SPARC_TILE) begin : g_sparc_core
         .transducer_l15_req_ack             (transducer_l15_req_ack)
     );
 
-
+`endif // ifdef PITON_OST1
 end
 endgenerate
 generate
 if (TILE_TYPE == `PICORV32_TILE) begin : g_picorv32_core
+`ifdef PITON_PICO
     ///////////////////
     // PicoRV32 Core //
     ///////////////////
@@ -899,6 +901,7 @@ if (TILE_TYPE == `PICORV32_TILE) begin : g_picorv32_core
         .pico_int                           (pico_int)
     );
 
+`endif // ifdef PITON_PICO
 end
 endgenerate
 generate
@@ -1064,7 +1067,7 @@ print(str)
 
     assign unavailable_o = 1'b0;
 
-`endif
+`endif // ifdef PITON_ARIANE
   end
   endgenerate
 

--- a/piton/tools/bin/pyhplib.py
+++ b/piton/tools/bin/pyhplib.py
@@ -58,6 +58,7 @@ if NUM_TILES == -1:
     else:
         NUM_TILES = MAX_TILE
 
+PITON_OST1     = int(os.environ.get('PITON_OST1', '0'))
 PITON_ARIANE   = int(os.environ.get('PITON_ARIANE', '0'))
 PITON_PICO     = int(os.environ.get('PITON_PICO', '0'))
 PITON_PICO_HET = int(os.environ.get('PITON_PICO_HET', '0'))

--- a/piton/tools/bin/rv32_as
+++ b/piton/tools/bin/rv32_as
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 echo $ASM_DIAG_NAME_NO_EXT
-riscv32-unknown-elf-gcc -march=rv32ima -mabi=ilp32 -nostdlib -nostartfiles   \
+${RV32_TARGET_TRIPLE}-gcc -march=${RV32_MARCH} -mabi=${RV32_MABI} -nostdlib -nostartfiles   \
                         -DTEST_FUNC_NAME=${ASM_DIAG_NAME_NO_EXT}             \
                         -DTEST_FUNC_TXT='"${ASM_DIAG_NAME_NO_EXT}"'          \
                         -DTEST_FUNC_RET=${ASM_DIAG_NAME_NO_EXT}_ret          \
@@ -33,15 +33,15 @@ riscv32-unknown-elf-gcc -march=rv32ima -mabi=ilp32 -nostdlib -nostartfiles   \
 
 # create mem.image
 #riscv32-unknown-elf-objcopy --reverse-bytes 4 -I elf32-littleriscv -O binary diag.exe diag.o
-riscv32-unknown-elf-objcopy -I elf32-littleriscv -O binary diag.exe diag.o
+${RV32_TARGET_TRIPLE}-objcopy -I elf32-littleriscv -O binary diag.exe diag.o
 du diag.o -b | awk '{print(128 - ($1 % 128));}' | xargs -t -ISIZE truncate diag.o -s +SIZE
 printf "\n@0000000040000000\t// Section '.RED_SEC', segment 'text'\n" >mem.image
 #od -tx -v -An -w32 diag.o >>mem.image
 xxd -g 16 -c 32 diag.o | awk '{printf("%s %s\n", $2, $3);}' >>mem.image
 
 #create symbol.tbl
-riscv32-unknown-elf-objdump -d diag.exe | grep "<pass>:" | awk '{printf("good_trap %s X %s\n", $1, $1);}' >symbol.tbl
-riscv32-unknown-elf-objdump -d diag.exe | grep "<fail>:" | awk '{printf("bad_trap %s X %s\n", $1, $1);}' >>symbol.tbl
+${RV32_TARGET_TRIPLE}-objdump -d diag.exe | grep "<pass>:" | awk '{printf("good_trap %s X %s\n", $1, $1);}' >symbol.tbl
+${RV32_TARGET_TRIPLE}-objdump -d diag.exe | grep "<fail>:" | awk '{printf("bad_trap %s X %s\n", $1, $1);}' >>symbol.tbl
 
 #create empty diag.ev
 touch diag.ev

--- a/piton/tools/bin/rv64_as
+++ b/piton/tools/bin/rv64_as
@@ -14,16 +14,16 @@
 # Description: mem image assembly script for rv64 targets
 
 # create mem.image
-riscv64-unknown-elf-objcopy -I elf64-littleriscv -O binary diag.exe diag.o
+${RV64_TARGET_TRIPLE}-objcopy -I elf64-littleriscv -O binary diag.exe diag.o
 # pad with zero to 128byte boundary
 du diag.o -b | awk '{print(128 - ($1 % 128));}' | xargs -t -ISIZE truncate diag.o -s +SIZE
 printf "\n@0000000080000000\t// Section '.RED_SEC', segment 'text'\n" > mem.image
 xxd -g 16 -c 32 diag.o | awk '{printf("%s %s\n", $2, $3);}' >> mem.image
 
 #create symbol.tbl
-riscv64-unknown-elf-objdump -d diag.exe | grep "<pass>:" | awk '{printf("good_trap %s X %s\n", $1, $1);}' >symbol.tbl
-riscv64-unknown-elf-objdump -d diag.exe | grep "<fail>:" | awk '{printf("bad_trap %s X %s\n", $1, $1);}' >>symbol.tbl
-riscv64-unknown-elf-objdump -d diag.exe --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data  > diag.dump
+${RV64_TARGET_TRIPLE}-objdump -d diag.exe | grep "<pass>:" | awk '{printf("good_trap %s X %s\n", $1, $1);}' >symbol.tbl
+${RV64_TARGET_TRIPLE}-objdump -d diag.exe | grep "<fail>:" | awk '{printf("bad_trap %s X %s\n", $1, $1);}' >>symbol.tbl
+${RV64_TARGET_TRIPLE}-objdump -d diag.exe --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data  > diag.dump
 
 #create empty diag.ev
 touch diag.ev

--- a/piton/tools/bin/rv64_cc
+++ b/piton/tools/bin/rv64_cc
@@ -17,8 +17,8 @@
 # second argument can be used to pass additional arguments to GCC.
 
 # Todo: upgrade from IMAC -> IMACFD when FP is available
-RISCV_GCC=riscv64-unknown-elf-gcc
-RISCV_GCC_OPTS="-march=rv64imac -mabi=lp64 -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -fno-common -fno-builtin-printf $2"
+RISCV_GCC=${RV64_TARGET_TRIPLE}-gcc
+RISCV_GCC_OPTS="-march=${RV64_MARCH} -mabi=${RV64_MABI} -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -fno-common -fno-builtin-printf $2"
 RISCV_LINK_OPTS="-static -nostdlib -nostartfiles -lm -lgcc -T ${DV_ROOT}/verif/diag/assembly/include/riscv/ariane/link.ld"
 
 # $(src_dir)/../env -I$(src_dir)/common $(addprefix -I$(src_dir)/, $(bmarks))

--- a/piton/tools/bin/rv64_img
+++ b/piton/tools/bin/rv64_img
@@ -26,7 +26,7 @@
 
 # create mem.image
 #riscv64-unknown-elf-objcopy --reverse-bytes 4 -I elf32-littleriscv -O binary diag.exe diag.o
-riscv64-unknown-elf-objcopy -I elf64-littleriscv -O binary diag.exe diag.o
+${RV64_TARGET_TRIPLE}-objcopy -I elf64-littleriscv -O binary diag.exe diag.o
 # pad with zero to 128byte boundary
 du diag.o -b | awk '{print(128 - ($1 % 128));}' | xargs -t -ISIZE truncate diag.o -s +SIZE
 printf "\n@0000000080000000\t// Section '.RED_SEC', segment 'text'\n" >mem.image
@@ -34,9 +34,9 @@ printf "\n@0000000080000000\t// Section '.RED_SEC', segment 'text'\n" >mem.image
 xxd -g 8 -c 32 diag.o | awk '{printf("%s %s %s %s\n", $2, $3, $4, $5);}' >> mem.image
 
 #create symbol.tbl
-riscv64-unknown-elf-objdump -d diag.exe | grep "<pass>:" | awk '{printf("good_trap %s X %s\n", $1, $1);}' >symbol.tbl
-riscv64-unknown-elf-objdump -d diag.exe | grep "<fail>:" | awk '{printf("bad_trap %s X %s\n", $1, $1);}' >>symbol.tbl
-riscv64-unknown-elf-objdump -d diag.exe --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data  > diag.dump
+${RV64_TARGET_TRIPLE}-objdump -d diag.exe | grep "<pass>:" | awk '{printf("good_trap %s X %s\n", $1, $1);}' >symbol.tbl
+${RV64_TARGET_TRIPLE}-objdump -d diag.exe | grep "<fail>:" | awk '{printf("bad_trap %s X %s\n", $1, $1);}' >>symbol.tbl
+${RV64_TARGET_TRIPLE}-objdump -d diag.exe --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data  > diag.dump
 
 #create empty diag.ev
 touch diag.ev

--- a/piton/tools/src/proto/common/setup.tcl
+++ b/piton/tools/src/proto/common/setup.tcl
@@ -88,7 +88,7 @@ if {[info exists ::env(PITON_PICO)]} {
 }
 
 if {[info exists ::env(PITON_PICO_HET)]} {
-  append ALL_DEFAULT_VERILOG_MACROS " PITON_PICO_HET"
+  append ALL_DEFAULT_VERILOG_MACROS " PITON_PICO PITON_PICO_HET"
 }
 
 if {[info exists ::env(PITON_ARIANE)]} {

--- a/piton/tools/src/proto/common/setup.tcl
+++ b/piton/tools/src/proto/common/setup.tcl
@@ -79,6 +79,10 @@ set ALL_DEFAULT_VERILOG_MACROS [concat \
     ${BOARD_DEFAULT_VERILOG_MACROS}    \
 ]
 
+if {[info exists ::env(PITON_OST1)]} {
+  append ALL_DEFAULT_VERILOG_MACROS " PITON_OST1"
+}
+
 if {[info exists ::env(PITON_PICO)]} {
   append ALL_DEFAULT_VERILOG_MACROS " PITON_PICO"
 }
@@ -100,6 +104,9 @@ for {set k 0} {$k < $::env(PTON_NUM_TILES)} {incr k} {
   }
   if {[info exists "::env(RTL_SPARC$k)"]} {
     append ALL_DEFAULT_VERILOG_MACROS " RTL_SPARC$k"
+  }
+  if {[info exists "::env(RTL_TILE$k)"]} {
+    append ALL_DEFAULT_VERILOG_MACROS " RTL_TILE$k"
   }
 }
 

--- a/piton/tools/src/proto/protosyn,2.5
+++ b/piton/tools/src/proto/protosyn,2.5
@@ -727,6 +727,10 @@ def main():
 
     # core variant
     print_info("core      = " + str(options.core))
+    for i in range(int(args.num_tiles)):
+        os.environ['RTL_TILE' + str(i)] = "1"
+        print_info('defining RTL_TILE' + str(i))
+
     if options.core == 'pico':
 
         os.environ['PITON_PICO']     = "1"
@@ -759,6 +763,7 @@ def main():
 
     elif options.core == 'sparc':
         # this is the default
+        os.environ['PITON_OST1'] = "1"
         for i in range(int(options.num_tiles)):
             os.environ['RTL_SPARC' + str(i)] = "1"
             print_info('setenv RTL_SPARC' + str(i))

--- a/piton/tools/src/proto/protosyn,2.5
+++ b/piton/tools/src/proto/protosyn,2.5
@@ -727,7 +727,7 @@ def main():
 
     # core variant
     print_info("core      = " + str(options.core))
-    for i in range(int(args.num_tiles)):
+    for i in range(int(options.num_tiles)):
         os.environ['RTL_TILE' + str(i)] = "1"
         print_info('defining RTL_TILE' + str(i))
 

--- a/piton/tools/src/sims/manycore.config
+++ b/piton/tools/src/sims/manycore.config
@@ -34,7 +34,10 @@
     -flist=$DV_ROOT/design/chip/tile/rtl/Flist.tile
     -flist=$DV_ROOT/design/chip/tile/rtap/rtl/Flist.rtap
     -flist=$DV_ROOT/design/chip/tile/l15/rtl/Flist.l15
+#ifdef FLIST_PICO
     -flist=$DV_ROOT/design/chip/tile/pico/rtl/Flist.pico
+#endif
+#ifdef FLIST_OST1
     -flist=$DV_ROOT/design/chip/tile/fpu/rtl/Flist.fpu
     -flist=$DV_ROOT/design/chip/tile/sparc/rtl/Flist.sparc_top
     -flist=$DV_ROOT/design/chip/tile/sparc/ifu/rtl/Flist.ifu
@@ -50,6 +53,10 @@
     -flist=$DV_ROOT/design/chip/tile/sparc/mul/rtl/Flist.mul
     -flist=$DV_ROOT/design/chip/tile/sparc/srams/rtl/Flist.srams
     -flist=$DV_ROOT/design/chip/tile/sparc/rtl/Flist.sparc_common
+#endif
+#ifdef FLIST_ARIANE
+    -flist=$DV_ROOT/design/chip/tile/ariane/Flist.ariane
+#endif
     -flist=$DV_ROOT/design/chip/tile/common/rtl/Flist.clib_common
     -flist=$DV_ROOT/design/chip/tile/common/rtl/Flist.dlib_common
     -flist=$DV_ROOT/design/chip/tile/common/rtl/Flist.dft_common
@@ -83,6 +90,9 @@
     //-flist=$DV_ROOT/design/chipset/mc/rtl/Flist.mc
     //axi_lite_slave_rf
     -flist=$DV_ROOT/design/chipset/axi_lite_slave_rf/rtl/Flist.axi_lite_slave_rf
+#ifdef PITON_ORAM
+    -flist=$DV_ROOT/design/chip/tinyoram/rtl/Flist.oram
+#endif
 
     // No scan chains
     -config_rtl=NO_SCAN

--- a/piton/tools/src/sims/sims,2.0
+++ b/piton/tools/src/sims/sims,2.0
@@ -348,6 +348,20 @@ GetOptions (\%opt,
             'build_id=s',
            ) ;
 
+die ("DIE. -ariane and -pico/-pico_het cannot be set simultaneously") if ($opt{ariane} && ($opt{pico} || $opt{pico_het})) ;
+die ("DIE. -pico and -pico_het cannot both be set") if ($opt{pico} && $opt{pico_het}) ;
+
+# Setting ost1 by default. This works better than default to 1
+# for heterogeneous-ISA stuff
+if (!$opt{pico} && !$opt{ariane}) {
+  $opt{ost1} = 1 ;
+}
+
+push (@{$opt{config_cpp_args}}, "-DFLIST_OST1")     if ($opt{ost1} || $opt{pico_het}) ;
+push (@{$opt{config_cpp_args}}, "-DFLIST_PICO")     if ($opt{pico} || $opt{pico_het}) ;
+push (@{$opt{config_cpp_args}}, "-DFLIST_ARIANE")   if ($opt{ariane}) ;
+push (@{$opt{config_cpp_args}}, "-DFLIST_ORAM")     if ($opt{oram}) ;
+
 ################################################################################
 # define $result_dir
 ################################################################################
@@ -1099,12 +1113,6 @@ sub gen_flist
   open (OFLIST, ">flist") or die ("DIE. can't open flist file") ;
 
   print OFLIST "$ENV{PWD}/config.v\n";
-
-  # Add ORAM flist if ORAM is specified
-  push (@{$opt{flist}}, "$ENV{DV_ROOT}/design/chip/tinyoram/rtl/Flist.oram") if ($opt{oram}) ;
-  # Add Ariane flist if -ariane is specified
-  push (@{$opt{flist}}, "$ENV{DV_ROOT}/design/chip/tile/ariane/Flist.ariane") if ($opt{ariane}) ;
-
 
   foreach my $flist (@{$opt{flist}}) {
     $flist =~ s/\$(\w+)/$ENV{$1}/g ;
@@ -2771,42 +2779,34 @@ sub parse_args
       die ("DIE. network_config can only be xbar_config or 2dmesh_config");
     }
   } else {
-    print "network_config not specified, assuming 2dmesh configuration\n";
+    print "$prg: network_config not specified, assuming 2dmesh configuration\n";
     $ENV{PTON_NETWORK_CONFIG}="2d_mesh";
-  }
-
-  # Setting ost1 by default. This works better than default to 1
-  # for heterogeneous-ISA stuff
-  if (!$opt{pico} && !$opt{ariane}) {
-    $opt{ost1} = 1 ;
   }
 
   # Set ISA to choose compilation flow based on ISA
   if ($opt{ost1}) {
     $opt{sparcv9} = 1 ;
-    print "Building/running for sparcv9\n" ;
+    print "$prg: Building/running for sparcv9\n" ;
   }
-  if ($opt{pico} || $opt{pico_het}) {
+  if ($opt{pico}) {
     $opt{rv32} = 1 ;
-    print "Building/running for rv32\n" ;
+    print "$prg: Building/running for rv32\n" ;
   }
   if ($opt{ariane}) {
     $opt{rv64} = 1 ;
-    print "Building/running for rv64\n" ;
+    print "$prg: Building/running for rv64\n" ;
   }
 
-  die ("DIE. -ariane and -pico/-pico_het cannot be set simultaneously") if ($opt{ariane} && ($opt{pico} || $opt{pico_het})) ;
-  die ("DIE. -pico and -pico_het cannot both be set") if ($opt{pico} && $opt{pico_het}) ;
   $ENV{PITON_OST1}     = $opt{ost1};
   $ENV{PITON_PICO}     = $opt{pico};
   $ENV{PITON_PICO_HET} = $opt{pico_het};
   $ENV{PITON_ARIANE}   = $opt{ariane};
   push (@{$opt{config_rtl}}, "PITON_OST1")     if ($opt{ost1});
   push (@{$opt{config_rtl}}, "PITON_PICO")     if ($opt{pico});
+  push (@{$opt{config_rtl}}, "PITON_PICO")     if ($opt{pico_het});
   push (@{$opt{config_rtl}}, "PITON_PICO_HET") if ($opt{pico_het});
   push (@{$opt{config_rtl}}, "PITON_ARIANE")   if ($opt{ariane});
   push (@{$opt{config_rtl}}, "WT_DCACHE")      if ($opt{ariane});
-
 
   if ($opt{pico} or $opt{pico_het} or $opt{ariane}) {
     push (@{$opt{config_rtl}}, "NO_MRA_VAL") ;
@@ -2864,7 +2864,7 @@ sub parse_args
 
   # Alexey: set default value for UART_DIV_LATCH define
   if (index("@{$opt{midas_args}}", "UART_DIV_LATCH") == -1) {
-    print "Setting UART_DIV_LATCH to 0xb\n";
+    print "$prg: Setting UART_DIV_LATCH to 0xb\n";
     push (@{$opt{midas_args}}, "-DUART_DIV_LATCH=0xb");
   }
 

--- a/piton/tools/src/sims/sims,2.0
+++ b/piton/tools/src/sims/sims,2.0
@@ -171,6 +171,7 @@ Getopt::Long::Configure ('no_auto_abbrev') ;
         'overwrite' => 0,
         'pal_use_tgseed' => 0,
         'parallel' => 0,
+        'ost1' => 0,
         'ariane' => 0,
         'pico' => 0,
         'pico_het' => 0,
@@ -321,6 +322,7 @@ GetOptions (\%opt,
             'group=s@',
             'model_dir=s',
             'parallel!',
+            'ost1!',
             'ariane!',
             'pico!',
             'pico_het!',
@@ -2707,11 +2709,19 @@ sub parse_args
     $ENV{PTON_NETWORK_CONFIG}="2d_mesh";
   }
 
+  # Setting ost1 by default. This works better than default to 1
+  # for heterogeneous-ISA stuff
+  if (!$opt{pico} && !$opt{ariane}) {
+    $opt{ost1} = 1 ;
+  }
+
   die ("DIE. -ariane and -pico/-pico_het cannot be set simultaneously") if ($opt{ariane} && ($opt{pico} || $opt{pico_het})) ;
   die ("DIE. -pico and -pico_het cannot both be set") if ($opt{pico} && $opt{pico_het}) ;
+  $ENV{PITON_OST1}     = $opt{ost1};
   $ENV{PITON_PICO}     = $opt{pico};
   $ENV{PITON_PICO_HET} = $opt{pico_het};
   $ENV{PITON_ARIANE}   = $opt{ariane};
+  push (@{$opt{config_rtl}}, "PITON_OST1")     if ($opt{ost1});
   push (@{$opt{config_rtl}}, "PITON_PICO")     if ($opt{pico});
   push (@{$opt{config_rtl}}, "PITON_PICO_HET") if ($opt{pico_het});
   push (@{$opt{config_rtl}}, "PITON_ARIANE")   if ($opt{ariane});
@@ -2748,11 +2758,12 @@ sub parse_args
   }
 
   for (my $i=0; $i < $pton_num_tiles; $i++) {
+    push (@{$opt{config_rtl}}, "RTL_TILE" . $i);
     if ($opt{pico} || ($opt{pico_het} && ($i % 2 == 1))) {
         push (@{$opt{config_rtl}}, "RTL_PICO" . $i);
     } elsif ($opt{ariane}) {
         push (@{$opt{config_rtl}}, "RTL_ARIANE" . $i);
-    } else {
+    } elsif ($opt{ost1}) {
         push (@{$opt{config_rtl}}, "RTL_SPARC" . $i);
     }
   }
@@ -3029,6 +3040,10 @@ VERILOG COMPILATION RELATED
     -build_id=NAME
            specify the build id of the model to be built. the full path
            to a model is $ENV{MODEL_DIR}/model/build_id.
+
+    -ost1
+           set by default - this specifies that the OpenSPARC T1 core will be used.
+           in this case, programs are compiled and assembled using midas
 
     -pico
            this specifies that the PICORV32 core shall be used instead of OpenSPARC.

--- a/piton/tools/src/sims/sims,2.0
+++ b/piton/tools/src/sims/sims,2.0
@@ -144,6 +144,7 @@ Getopt::Long::Configure ('no_auto_abbrev') ;
         'fast_boot' => 0,
         'finish_mask' => "",
         'flist' => [],
+        'gcc_args' => [],
         'group' => [],
         'group_name' => "",
         'gzip' => 1,
@@ -190,6 +191,14 @@ Getopt::Long::Configure ('no_auto_abbrev') ;
         'riv_run' => 0,		
         'rtl_timeout' => 5000,
         'run_diag_pl' => 1,
+        'rv32' => 0,
+        'rv32_mabi=s' => "",
+        'rv32_march=s' => "",
+        'rv32_target_triple=s' => "",
+        'rv64' => 0,
+        'rv64_mabi=s' => "",
+        'rv64_march=s' => "",
+        'rv64_target_triple=s' => "",
         'other_sim_build' => 0,
         'sim_build_args' => [],
         'other_sim_build_cmd' => "",
@@ -205,6 +214,7 @@ Getopt::Long::Configure ('no_auto_abbrev') ;
         'sjm_diag_name' => "",
         'sjm_diag_path' => "",
         'sjm_diag_root' => [],
+        'sparcv9' => 0,
         'stub_mask' => "",
         'sys' => "",
         'tg_seed' => -1,
@@ -2252,8 +2262,30 @@ sub assemble_diag
       close (DIAGIN) ;
     }
 
-    if ($opt{pico}) {
-      # RISCV flow for RV32IM (PICORV32)
+    # Choose compilation flow based on ISA
+    if ($opt{rv32}) {
+      # RISCV flow for RV32
+      if (!$opt{rv32_target_triple}) {
+        if ($opt{pico}) {
+          $ENV{RV32_TARGET_TRIPLE} = "riscv32-unknown-elf" ;
+        }
+      } else {
+        $ENV{RV32_TARGET_TRIPLE} = $opt{rv32_target_triple} ;
+      }
+      if (!$opt{rv32_march}) {
+        if ($opt{pico}) {
+          $ENV{RV32_MARCH} = "rv32ima" ;
+        }
+      } else {
+        $ENV{RV32_MARCH} = $opt{rv32_march} ;
+      }
+      if (!$opt{rv32_mabi}) {
+        if ($opt{pico}) {
+          $ENV{RV32_MABI} = "ilp32" ;
+        }
+      } else {
+        $ENV{RV32_MABI} = $opt{rv32_mabi} ;
+      }
       print "$prg: assembling 32bit riscv diag (RV32IM)\n" ;
       my $cmd = "rv32_as " ;
       #$cmd .= join (" ", @{$opt{midas_args}}) ;
@@ -2262,8 +2294,30 @@ sub assemble_diag
       my $waitstatus = call_program($cmd, "rv32_as.log");
       die ("DIE. rv32_as compilation error") if ($waitstatus) ;
 
-    } elsif ($opt{ariane}) {
-      # RISCV flow for RV64IMAC (ARIANE from PULP)
+    }
+    if ($opt{rv64}) {
+      # RISCV flow for RV64
+      if (!$opt{rv64_target_triple}) {
+        if ($opt{ariane}) {
+          $ENV{RV64_TARGET_TRIPLE} = "riscv64-unknown-elf" ;
+        }
+      } else {
+        $ENV{RV64_TARGET_TRIPLE} = $opt{rv64_target_triple} ;
+      }
+      if (!$opt{rv64_march}) {
+        if ($opt{ariane}) {
+          $ENV{RV64_MARCH} = "rv64imafdc" ;
+        }
+      } else {
+        $ENV{RV64_MARCH} = $opt{rv64_march} ;
+      }
+      if (!$opt{rv64_mabi}) {
+        if ($opt{ariane}) {
+          $ENV{RV64_MABI} = "lp64d" ;
+        }
+      } else {
+        $ENV{RV64_MABI} = $opt{rv64_mabi} ;
+      }
       # only recompile if necessary
       if (!$opt{precompiled}) {
         print "$prg: assembling 64bit riscv diag (RV64IMAC)\n" ;
@@ -2271,7 +2325,9 @@ sub assemble_diag
         if ($opt{uart_dmw}) {
           $defs .= " -DPITONSTREAM ";
         }
-        $defs .= $opt{gcc_args};
+        foreach my $additional_args (@{$opt{gcc_args}}) {
+          $defs .= " ${additional_args}";
+        }
         my $cmd = "rv64_cc ${diag_name} \"$defs\"" ;
         print "$prg: $cmd\n";
         my $waitstatus = call_program($cmd, "rv64_cc.log");
@@ -2311,7 +2367,8 @@ sub assemble_diag
         }
         close($fh);
       }
-    } else {
+    }
+    if ($opt{sparcv9}) {
       # standard flow for SAPRC
       # assemble
       push (@{$opt{midas_args}}, "-DFAST_BOOT") if ($opt{fast_boot}) ;
@@ -2471,7 +2528,7 @@ sub parse_args
             'asm_diag_root=s@',
             'build!',
             'precompiled!',
-            'gcc_args=s',
+            'gcc_args=s@',
             'uart_dmw!',
             'trap_offset=s',
             'config_cpp_args=s@',
@@ -2529,6 +2586,14 @@ sub parse_args
             'riv_run!',
             'rtl_timeout=i',
             'run_diag_pl!',
+            'rv32!',
+            'rv32_mabi=s',
+            'rv32_march=s',
+            'rv32_target_triple=s',
+            'rv64!',
+            'rv64_mabi=s',
+            'rv64_march=s',
+            'rv64_target_triple=s',
             'other_sim_build!',
             'sim_build_args=s@',
             'other_sim_build_cmd=s',
@@ -2544,6 +2609,7 @@ sub parse_args
             'sjm_diag_name=s',
             'sjm_diag_path=s',
             'sjm_diag_root=s@',
+            'sparcv9!',
             'stub_mask=s',
             'sys=s',
             'tg_seed=i',
@@ -2713,6 +2779,20 @@ sub parse_args
   # for heterogeneous-ISA stuff
   if (!$opt{pico} && !$opt{ariane}) {
     $opt{ost1} = 1 ;
+  }
+
+  # Set ISA to choose compilation flow based on ISA
+  if ($opt{ost1}) {
+    $opt{sparcv9} = 1 ;
+    print "Building/running for sparcv9\n" ;
+  }
+  if ($opt{pico} || $opt{pico_het}) {
+    $opt{rv32} = 1 ;
+    print "Building/running for rv32\n" ;
+  }
+  if ($opt{ariane}) {
+    $opt{rv64} = 1 ;
+    print "Building/running for rv64\n" ;
   }
 
   die ("DIE. -ariane and -pico/-pico_het cannot be set simultaneously") if ($opt{ariane} && ($opt{pico} || $opt{pico_het})) ;
@@ -3126,6 +3206,30 @@ this is the compiler used for RISC-V cores (e.g., when the -pico or -ariane swit
 
     -gcc_args
            additional gcc arguments
+
+    -rv32_target_triple
+           specifies rv32 cross-compiler prefix (e.g. riscv32-unknown-elf)
+           default varies by core
+
+    -rv32_march
+           specifies rv32 march string (e.g. rv32ima)
+           default varies by core
+
+    -rv32_mabi
+           specifies rv32 mabi string (e.g. ilp32)
+           default varies by core
+
+    -rv64_target_triple
+           specifies rv64 cross-compiler prefix (e.g. riscv64-unknown-elf)
+           default varies by core
+
+    -rv64_march
+           specifies rv64 march string (e.g. rv64imafdc)
+           default varies by core
+
+    -rv64_mabi
+           specifies rv64 mabi string (e.g. lp64d)
+           default varies by core
 
 VCS COVERMETER
 

--- a/piton/tools/src/tursi/tursi,1.0
+++ b/piton/tools/src/tursi/tursi,1.0
@@ -422,6 +422,10 @@ def main():
 
     # core variant
     print_info("core      = " + str(args.core))
+    for i in range(int(args.num_tiles)):
+        args.config_rtl.append('RTL_TILE' + str(i))
+        print_info('defining RTL_TILE' + str(i))
+
     if args.core == 'pico':
 
         args.config_rtl.append('PITON_PICO')
@@ -457,6 +461,7 @@ def main():
 
     elif args.core == 'sparc':
         # this is the default
+        args.config_rtl.append('PITON_OST1')
         for i in range(int(args.num_tiles)):
             args.config_rtl.append('RTL_SPARC' + str(i))
             print_info('defining RTL_SPARC' + str(i))

--- a/piton/verif/env/manycore/cross_module.h.pyv
+++ b/piton/verif/env/manycore/cross_module.h.pyv
@@ -102,15 +102,6 @@ for i in range(NUM_TILES):
     `define ARIANE_CORE%d     `TILE%d.g_ariane_core.core.ariane
     `define SPARC_CORE%d      `TILE%d.g_sparc_core.core
     `define PICO_CORE%d       `TILE%d.g_picorv32_core.core
-    `ifdef RTL_SPARC%d
-    `define CORE_REF%d        `SPARC_CORE%d
-    `endif // ifdef RTL_SPARC%d
-    `ifdef RTL_ARIANE%d
-    `define CORE_REF%d        `TILE%d.g_ariane_core.core
-    `endif // ifdef RTL_ARIANE%d
-    `ifdef RTL_PICO%d
-    `define CORE_REF%d        `PICO_CORE%d
-    `endif // ifdef RTL_PICO%d
     `define CCX_TRANSDUCER%d  `TILE%d.g_sparc_core.ccx_l15_transducer
     `define PICO_TRANSDUCER%d `TILE%d.g_picorv32_core.pico_l15_transducer
     `define L15_TOP%d         `TILE%d.l15.l15

--- a/piton/verif/env/manycore/manycore_network_mon.v.pyv
+++ b/piton/verif/env/manycore/manycore_network_mon.v.pyv
@@ -71,7 +71,7 @@ begin
     for y in range (Y_TILES):
         for x in range (X_TILES):
             flatid = x + (y * X_TILES);
-            print("`ifdef RTL_SPARC%d" % flatid)
+            print("`ifdef RTL_TILE%d" % flatid)
             for nocid in [1,2,3]:
                 for dir in ['N', 'S', 'E', 'W']:
                     for way in ['out']:
@@ -110,7 +110,7 @@ begin
                 check_right = True;
                 check_up = True;
                 check_down = True;
-                print("`ifdef RTL_SPARC%d" % flatid)
+                print("`ifdef RTL_TILE%d" % flatid)
                 for nocid in [1,2,3]:
                     if (y == 0):
                         print("boundary_err = boundary_err | `CHIP.tile_%d_%d_out_N_noc%d_valid;" % (y,x,nocid))
@@ -156,7 +156,7 @@ begin
                         check_left = False;
 
                     if (check_up):
-                        print("`ifndef RTL_SPARC%d" % flatid_up)
+                        print("`ifndef RTL_TILE%d" % flatid_up)
                         print("boundary_err = boundary_err | `CHIP.tile_%d_%d_out_N_noc%d_valid;" % (y,x,nocid))
                         print('if (boundary_err == 1)')
                         print('begin')
@@ -167,7 +167,7 @@ begin
                         print('end')
                         print('`endif')
                     if (check_down):
-                        print("`ifndef RTL_SPARC%d" % flatid_down)
+                        print("`ifndef RTL_TILE%d" % flatid_down)
                         print("boundary_err = boundary_err | `CHIP.tile_%d_%d_out_S_noc%d_valid;" % (y,x,nocid))
                         print('if (boundary_err == 1)')
                         print('begin')
@@ -178,7 +178,7 @@ begin
                         print('end')
                         print('`endif')
                     if (check_left):
-                        print("`ifndef RTL_SPARC%d" % flatid_left)
+                        print("`ifndef RTL_TILE%d" % flatid_left)
                         print("boundary_err = boundary_err | `CHIP.tile_%d_%d_out_W_noc%d_valid;" % (y,x,nocid))
                         print('if (boundary_err == 1)')
                         print('begin')
@@ -189,7 +189,7 @@ begin
                         print('end')
                         print('`endif')
                     if (check_right):
-                        print("`ifndef RTL_SPARC%d" % flatid_right)
+                        print("`ifndef RTL_TILE%d" % flatid_right)
                         print("boundary_err = boundary_err | `CHIP.tile_%d_%d_out_E_noc%d_valid;" % (y,x,nocid))
                         print('if (boundary_err == 1)')
                         print('begin')
@@ -221,7 +221,7 @@ begin
                 # Check for valid signal from non-existent tiles to any other tiles.
                 # For example, if there is only tile 0_0 and 0_1, then
                 print('boundary_err = 0;')
-                print("`ifndef RTL_SPARC%d" % flatid)
+                print("`ifndef RTL_TILE%d" % flatid)
                 for nocid in [1,2,3]:
                     if (x != X_TILES-1):
                         check_right = True
@@ -233,7 +233,7 @@ begin
                         check_up = True
 
                     if (check_up):
-                        print("`ifdef RTL_SPARC%d" % flatid_up)
+                        print("`ifdef RTL_TILE%d" % flatid_up)
                         print("boundary_err = boundary_err | `CHIP.tile_%d_%d_out_N_noc%d_valid;" % (y,x,nocid))
                         print('if (boundary_err == 1)')
                         print('begin')
@@ -244,7 +244,7 @@ begin
                         print('end')
                         print('`endif')
                     if (check_down):
-                        print("`ifdef RTL_SPARC%d" % flatid_down)
+                        print("`ifdef RTL_TILE%d" % flatid_down)
                         print("boundary_err = boundary_err | `CHIP.tile_%d_%d_out_S_noc%d_valid;" % (y,x,nocid))
                         print('if (boundary_err == 1)')
                         print('begin')
@@ -255,7 +255,7 @@ begin
                         print('end')
                         print('`endif')
                     if (check_left):
-                        print("`ifdef RTL_SPARC%d" % flatid_left)
+                        print("`ifdef RTL_TILE%d" % flatid_left)
                         print("boundary_err = boundary_err | `CHIP.tile_%d_%d_out_W_noc%d_valid;" % (y,x,nocid))
                         print('if (boundary_err == 1)')
                         print('begin')
@@ -266,7 +266,7 @@ begin
                         print('end')
                         print('`endif')
                     if (check_right):
-                        print("`ifdef RTL_SPARC%d" % flatid_right)
+                        print("`ifdef RTL_TILE%d" % flatid_right)
                         print("boundary_err = boundary_err | `CHIP.tile_%d_%d_out_E_noc%d_valid;" % (y,x,nocid))
                         print('if (boundary_err == 1)')
                         print('begin')

--- a/piton/verif/env/manycore/manycore_top.v.pyv
+++ b/piton/verif/env/manycore/manycore_top.v.pyv
@@ -530,35 +530,29 @@ system system(
 //        need_sas_sparc_intf_update  = 1;
 //    end // initial begin
 
-`ifndef PITON_PICO
-`ifndef PITON_ARIANE
+`ifdef PITON_OST1
     sas_intf  sas_intf(/*AUTOINST*/
         // Inputs
         .clk       (`CHIP_INT_CLK),      // Templated
         .rst_l     (`CORE_REF0.reset_l));       // Templated
 `endif
-`endif
 
-`ifndef PITON_PICO
-`ifndef PITON_ARIANE
+`ifndef PITON_OST1
     // create sas tasks
     sas_tasks sas_tasks(/*AUTOINST*/
         // Inputs
         .clk      (`CHIP_INT_CLK),      // Templated
         .rst_l        (`CORE_REF0.reset_l));       // Templated
 `endif
-`endif
 
-`ifndef PITON_ARIANE
+`ifdef PITON_OST1
     // sparc pipe flow monitor
     sparc_pipe_flow sparc_pipe_flow(/*AUTOINST*/
         // Inputs
         .clk  (`CHIP_INT_CLK));         // Templated
 `endif
 
-`ifndef PITON_PICO_HET
     manycore_network_mon network_mon (`CHIP_INT_CLK);
-`endif
 
 `endif // MINIMAL_MONITORING
 `endif // DISABLE_ALL_MONITORS

--- a/piton/verif/env/manycore/manycore_top.v.pyv
+++ b/piton/verif/env/manycore/manycore_top.v.pyv
@@ -537,7 +537,7 @@ system system(
         .rst_l     (`CORE_REF0.reset_l));       // Templated
 `endif
 
-`ifndef PITON_OST1
+`ifdef PITON_OST1
     // create sas tasks
     sas_tasks sas_tasks(/*AUTOINST*/
         // Inputs

--- a/piton/verif/env/manycore/manycore_top.v.pyv
+++ b/piton/verif/env/manycore/manycore_top.v.pyv
@@ -430,7 +430,7 @@ system system(
     monitor   monitor(
         .clk    (`CHIP_INT_CLK),
         .cmp_gclk  (`CHIP_INT_CLK),
-        .rst_l     (`CORE_REF0.reset_l)
+        .rst_l     (`CHIP.rst_n_inter_sync)
         );
 
 `ifndef MINIMAL_MONITORING
@@ -487,7 +487,7 @@ system system(
 
 `ifndef VERILATOR
     // T1's TSO monitor, stripped of all L2 references
-    tso_mon tso_mon(`CHIP_INT_CLK, `CORE_REF0.reset_l);
+    tso_mon tso_mon(`CHIP_INT_CLK, `CHIP.rst_n_inter_sync);
 `endif
 
     // L15 MONITORS
@@ -534,7 +534,7 @@ system system(
     sas_intf  sas_intf(/*AUTOINST*/
         // Inputs
         .clk       (`CHIP_INT_CLK),      // Templated
-        .rst_l     (`CORE_REF0.reset_l));       // Templated
+        .rst_l     (`CHIP.rst_n_inter_sync));       // Templated
 `endif
 
 `ifdef PITON_OST1
@@ -542,7 +542,7 @@ system system(
     sas_tasks sas_tasks(/*AUTOINST*/
         // Inputs
         .clk      (`CHIP_INT_CLK),      // Templated
-        .rst_l        (`CORE_REF0.reset_l));       // Templated
+        .rst_l        (`CHIP.rst_n_inter_sync));       // Templated
 `endif
 
 `ifdef PITON_OST1

--- a/piton/verif/env/manycore/monitor.v.pyv
+++ b/piton/verif/env/manycore/monitor.v.pyv
@@ -1281,21 +1281,11 @@ module monitor(/*AUTOARG*/
 
 `endif // ifdef GATE_SIM
 
-`ifdef RTL_SPARC0
+`ifdef RTL_TILE0
    //monitor good trap and bad trap.
    pc_cmp pc_cmp(clk, rst_l); // Sumti - Shifting it back to clk, sas race with +fast_boot.
 //dump cache
-`endif // ifdef RTL_SPARC0
-
-`ifdef RTL_PICO0
-   //monitor good trap and bad trap.
-   pc_cmp pc_cmp(clk, rst_l); // Sumti - Shifting it back to clk, sas race with +fast_boot.
-`endif // ifdef RTL_PICO0
-
-`ifdef RTL_ARIANE0
-   //monitor good trap and bad trap.
-   pc_cmp pc_cmp(clk, rst_l); // Sumti - Shifting it back to clk, sas race with +fast_boot.
-`endif // ifdef RTL_ARIANE0
+`endif // ifdef RTL_TILE0
 
 	// dump_cache dump_cache();
 

--- a/piton/verif/env/manycore/pc_cmp.v.pyv
+++ b/piton/verif/env/manycore/pc_cmp.v.pyv
@@ -325,10 +325,8 @@ initial begin
      trap_extract;
     done    = 0;
     good    = 0;
-`ifndef PITON_PICO
-`ifndef PITON_ARIANE
+`ifdef PITON_OST1
     active_thread = 0;
-`endif
 `endif
     hit_bad   = 0;
     first_rst = 1;
@@ -336,10 +334,8 @@ initial begin
 end // initial begin
 always @(posedge rst_l)begin
     if(first_rst)begin
-`ifndef PITON_PICO
-`ifndef PITON_ARIANE
+`ifndef PITON_OST1
         active_thread = 0;
-`endif
 `endif
         first_rst     = 0;
         done          = 0;


### PR DESCRIPTION
Sims was pretty tied to our local pico and ariane environments for the rv32 and rv64 flows. I'm trying to make this a little more generic. There's also some cleanup that I did around the `RTL_SPARC0..N` macros.

Summary:
- Added new `RTL_TILE0..N` macros so that manycore_network_mon can be used with non-sparc cores
- Added new `PITON_OST1` high-level macro and env var so we can build without OST1 RTL
- Changed some chains of `ifndef PITON_PICO ifndef PITON_ARIANE` etc to just be `ifdef PITON_OST1`
- Refactored rv32 and rv64 build flows to take environment variables for the target triple, march, and mabi. This varies with some newer cores we're integrating and based on people's environments. One can now use -rv64_march= to sims to specify a different march string, for example
- Added new implicit -ost1 and -sparcv9 arguments to sims which are set by default if other cores/ISAs aren't in use. Also added implicit -rv32 and -rv64 for pico and ariane.

I haven't seen these changes break anything yet but I haven't done a ton of testing. Most of this shouldn't affect FPGA for example but the FPGA flows do seem to set some of the `RTL_SPARC` etc macros even though they should only be used in non-synthesisable code. We may want to clean that up later.