### PR TITLE
Inverting NO_MRA_VAL and NO_SLAM_RANDOM

### DIFF
--- a/piton/tools/src/sims/sims,2.0
+++ b/piton/tools/src/sims/sims,2.0
@@ -2808,11 +2808,6 @@ sub parse_args
   push (@{$opt{config_rtl}}, "PITON_ARIANE")   if ($opt{ariane});
   push (@{$opt{config_rtl}}, "WT_DCACHE")      if ($opt{ariane});
 
-  if ($opt{pico} or $opt{pico_het} or $opt{ariane}) {
-    push (@{$opt{config_rtl}}, "NO_MRA_VAL") ;
-    push (@{$opt{config_rtl}}, "NO_SLAM_RANDOM") ;
-  }
-
   my $pton_x_tiles="";
   my $pton_y_tiles="";
   my $pton_num_tiles="";
@@ -2889,9 +2884,9 @@ sub parse_args
   push (@{$opt{config_rtl}}, "ORAM_ON") if ($opt{oram}) ;
   push (@{$opt{sim_run_args}}, "+oram") if ($opt{oram}) ;
 
-  if ($opt{msm_build} or $opt{icv_build} or $opt{vlt_build}) {
-      push(@{$opt{config_rtl}}, "NO_SLAM_RANDOM") ;
-      push(@{$opt{config_rtl}}, "NO_MRA_VAL") ;
+  if ($opt{vcs_build} or $opt{ncv_build} or $opt{riv_build}) {
+      push(@{$opt{config_rtl}}, "OST1_PLI_SLAM_RANDOM") ;
+      push(@{$opt{config_rtl}}, "OST1_PLI_MRA_VAL") ;
   }
 
 }

--- a/piton/tools/src/tursi/tursi,1.0
+++ b/piton/tools/src/tursi/tursi,1.0
@@ -416,8 +416,6 @@ def main():
     args.config_rtl.append('NO_SCAN')
 
     if args.fusesoc_core == "openpiton::manycore_tb":
-        args.config_rtl.append('NO_SLAM_RANDOM')
-        args.config_rtl.append('NO_MRA_VAL')
         args.config_rtl.append('PITON_DPI')
 
     # core variant

--- a/piton/verif/env/manycore/manycore_top.v.pyv
+++ b/piton/verif/env/manycore/manycore_top.v.pyv
@@ -443,7 +443,8 @@ system system(
     //  and it is randomized. For some reason if we left it as X's some tests will fail
     <%
         t = '''
-        `ifndef NO_SLAM_RANDOM
+        `ifdef OST1_PLI_SLAM_RANDOM
+        `ifdef RTL_SPARC0
         initial begin
             $slam_random(`SPARC_REG0.bw_r_irf_core.register01.bw_r_irf_register.window, 8, 0);
             $slam_random(`SPARC_REG0.bw_r_irf_core.register02.bw_r_irf_register.window, 8, 0);
@@ -478,10 +479,12 @@ system system(
             $slam_random(`SPARC_REG0.bw_r_irf_core.register31.bw_r_irf_register.window, 8, 0);
         end
         `endif
+        `endif
         '''
 
         for i in range(PITON_NUM_TILES) :
             tt = t.replace('SPARC_REG0', 'SPARC_REG%d' % i)
+            tt = t.replace('RTL_SPARC0', 'RTL_SPARC%d' % i)
             print(tt)
     %>
 

--- a/piton/verif/env/manycore/sas_task.v
+++ b/piton/verif/env/manycore/sas_task.v
@@ -2109,7 +2109,7 @@ task process_mra;
     reg all_update;
 
     begin
-`ifndef NO_MRA_VAL
+`ifdef OST1_PLI_MRA_VAL
         `SAS_TASKS.mra_val(cpu_id[9:0], mra_wr_ptr_d2, mra_wdata);
 `endif
         mra_thrid  = mra_wr_ptr_d2[3:2];

--- a/piton/verif/env/manycore/sas_tasks.v.pyv
+++ b/piton/verif/env/manycore/sas_tasks.v.pyv
@@ -742,7 +742,7 @@ initial begin
     swap         = 0;
 end // initial begin
 
-`ifndef NO_MRA_VAL
+`ifdef OST1_PLI_MRA_VAL
 //mra memory contets
 task mra_val;
     input [9:0] cpu;
@@ -878,7 +878,7 @@ task mra_val;
         endcase // case(cpu)
     end
 endtask // mra_val
-`endif // endif NO_MRA_VAL
+`endif // endif OST1_PLI_MRA_VAL
 reg timestamp, timest;
 reg [63:0] time_stamp;
 reg         pli_flag;


### PR DESCRIPTION
Inverting the Verilog macros NO_MRA_VAL and NO_SLAM_RANDOM to OST1_PLI_MRA_VAL and OST1_PLI_SLAM_RANDOM to simplify sims etc

I'd rather the code was only included when supported rather than removed in an increasing number of cases. These changes should remove the need to keep listing more and more cores to remove the code under.