### PR TITLE
ariane to cva6

### DIFF
--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -902,7 +902,7 @@ if (TILE_TYPE == `PICORV32_TILE) begin : g_picorv32_core
 end
 endgenerate
 generate
-if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_ariane_core
+if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_cva6_core
     //////////////////////
     // Ariane RV64 Core //
     //////////////////////
@@ -972,7 +972,7 @@ if (TILE_TYPE == `ARIANE_RV64_TILE) begin : g_ariane_core
                                      transducer_l15_rqtype == `PCX_REQTYPE_IFILL && 
                                     ~transducer_l15_invalidate_cacheline) ? `MSG_DATA_SIZE_32B : `MSG_DATA_SIZE_16B; 
 
-    wire [63:0] ariane_bootaddr;
+    wire [63:0] cva6_bootaddr;
 
 <%
 
@@ -1002,7 +1002,7 @@ if PITON_ARIANE:
             else:
               execBase   += "64'h" + cacheBase
               execLength += "64'h" + cacheLength
-        if devices[i]["name"] == "ariane_debug":
+        if devices[i]["name"] == "cva6_debug":
             dmBase       = "%X" % devices[i]["base"]
             dmLength     = "%X" % devices[i]["length"]
             numRules    += 1
@@ -1012,7 +1012,7 @@ if PITON_ARIANE:
             else:
               execBase   += "64'h" + dmBase
               execLength += "64'h" + dmLength
-        if devices[i]["name"] == "ariane_bootrom":
+        if devices[i]["name"] == "cva6_bootrom":
             romBase      = "%X" % devices[i]["base"]
             romLength    = "%X" % devices[i]["length"]
             numRules    += 1
@@ -1031,11 +1031,11 @@ bootAddr = cacheBase
 if romIsPresent:
   bootAddr = romBase
 
-print("    assign ariane_bootaddr  =  64'h%s;" % bootAddr)
+print("    assign cva6_bootaddr  =  64'h%s;" % bootAddr)
 %>
 
 
-    ariane_verilog_wrap #(
+    cva6_verilog_wrap #(
 <%
 str = '''
         .DmBaseAddress          ( 64'h%s ),
@@ -1052,7 +1052,7 @@ print(str)
         .clk_i       ( clk_gated              ),
         .reset_l     ( rst_n_f                ),
         .spc_grst_l  ( spc_grst_l             ),
-        .boot_addr_i ( ariane_bootaddr        ),
+        .boot_addr_i ( cva6_bootaddr        ),
         .hart_id_i   ( {{64-`JTAG_FLATID_WIDTH{1'b0}}, flat_tileid} ),
         .irq_i       ( irq_i                  ),
         .ipi_i       ( ipi_i                  ),

--- a/piton/design/chipset/noc_axilite_bridge/rtl/noc_axilite_bridge.v
+++ b/piton/design/chipset/noc_axilite_bridge/rtl/noc_axilite_bridge.v
@@ -50,7 +50,7 @@ module noc_axilite_bridge #(
     // note that the accesses are still 64bit, but the
     // write-enables are generated according to the access size
     parameter SLAVE_RESP_BYTEWIDTH = 4,
-    // swap endianess, needed when used in conjunction with a little endian core like Ariane
+    // swap endianess, needed when used in conjunction with a little endian core like Cva6
     parameter SWAP_ENDIANESS       = 0,
     // shift unaligned read data
     parameter ALIGN_RDATA          = 1

--- a/piton/design/chipset/rtl/chipset_impl.v.pyv
+++ b/piton/design/chipset/rtl/chipset_impl.v.pyv
@@ -1128,14 +1128,14 @@ fake_uart fake_uart (
     assign irq_sources = {net_interrupt, uart_interrupt};
 
     // this is for selecting the right bootrom (1: baremetal, 0: linux)
-    wire ariane_boot_sel;
+    wire cva6_boot_sel;
 `ifdef PITON_FPGA_SYNTH
-  assign ariane_boot_sel   = uart_boot_en;
+  assign cva6_boot_sel   = uart_boot_en;
 `else
   `ifdef ARIANE_SIM_LINUX_BOOT
-    assign ariane_boot_sel = 1'b0;
+    assign cva6_boot_sel = 1'b0;
   `else
-    assign ariane_boot_sel = 1'b1;
+    assign cva6_boot_sel = 1'b1;
   `endif
 `endif
 
@@ -1145,16 +1145,16 @@ RomBase   = 0
 ClintBase = 0
 PlicBase  = 0
 for i in range(len(devices)):
-    if devices[i]["name"] == "ariane_debug":
+    if devices[i]["name"] == "cva6_debug":
         DmBase = devices[i]["base"]
-    if devices[i]["name"] == "ariane_bootrom":
+    if devices[i]["name"] == "cva6_bootrom":
         RomBase = devices[i]["base"]
-    if devices[i]["name"] == "ariane_clint":
+    if devices[i]["name"] == "cva6_clint":
         ClintBase = devices[i]["base"]
-    if devices[i]["name"] == "ariane_plic":
+    if devices[i]["name"] == "cva6_plic":
         PlicBase = devices[i]["base"]
 str = '''
-    riscv_peripherals #(
+    cva6_riscv_peripherals #(
         .DataWidth      ( `NOC_DATA_WIDTH ),
         .NumHarts       (      `NUM_TILES ),
         .NumSources     (               2 ),
@@ -1167,32 +1167,32 @@ str = '''
         .clk_i                           ( chipset_clk                   ),
         .rst_ni                          ( chipset_rst_n                 ),
         .testmode_i                      ( 1'b0                          ),
-        .buf_ariane_debug_noc2_data_i    ( buf_ariane_debug_noc2_data    ),
-        .buf_ariane_debug_noc2_valid_i   ( buf_ariane_debug_noc2_valid   ),
-        .ariane_debug_buf_noc2_ready_o   ( ariane_debug_buf_noc2_ready   ),
-        .ariane_debug_buf_noc3_data_o    ( ariane_debug_buf_noc3_data    ),
-        .ariane_debug_buf_noc3_valid_o   ( ariane_debug_buf_noc3_valid   ),
-        .buf_ariane_debug_noc3_ready_i   ( buf_ariane_debug_noc3_ready   ),
-        .buf_ariane_bootrom_noc2_data_i  ( buf_ariane_bootrom_noc2_data  ),
-        .buf_ariane_bootrom_noc2_valid_i ( buf_ariane_bootrom_noc2_valid ),
-        .ariane_bootrom_buf_noc2_ready_o ( ariane_bootrom_buf_noc2_ready ),
-        .ariane_bootrom_buf_noc3_data_o  ( ariane_bootrom_buf_noc3_data  ),
-        .ariane_bootrom_buf_noc3_valid_o ( ariane_bootrom_buf_noc3_valid ),
-        .buf_ariane_bootrom_noc3_ready_i ( buf_ariane_bootrom_noc3_ready ),
-        .buf_ariane_clint_noc2_data_i    ( buf_ariane_clint_noc2_data    ),
-        .buf_ariane_clint_noc2_valid_i   ( buf_ariane_clint_noc2_valid   ),
-        .ariane_clint_buf_noc2_ready_o   ( ariane_clint_buf_noc2_ready   ),
-        .ariane_clint_buf_noc3_data_o    ( ariane_clint_buf_noc3_data    ),
-        .ariane_clint_buf_noc3_valid_o   ( ariane_clint_buf_noc3_valid   ),
-        .buf_ariane_clint_noc3_ready_i   ( buf_ariane_clint_noc3_ready   ),
-        .buf_ariane_plic_noc2_data_i     ( buf_ariane_plic_noc2_data     ),
-        .buf_ariane_plic_noc2_valid_i    ( buf_ariane_plic_noc2_valid    ),
-        .ariane_plic_buf_noc2_ready_o    ( ariane_plic_buf_noc2_ready    ),
-        .ariane_plic_buf_noc3_data_o     ( ariane_plic_buf_noc3_data     ),
-        .ariane_plic_buf_noc3_valid_o    ( ariane_plic_buf_noc3_valid    ),
-        .buf_ariane_plic_noc3_ready_i    ( buf_ariane_plic_noc3_ready    ),
+        .buf_cva6_debug_noc2_data_i    ( buf_cva6_debug_noc2_data    ),
+        .buf_cva6_debug_noc2_valid_i   ( buf_cva6_debug_noc2_valid   ),
+        .cva6_debug_buf_noc2_ready_o   ( cva6_debug_buf_noc2_ready   ),
+        .cva6_debug_buf_noc3_data_o    ( cva6_debug_buf_noc3_data    ),
+        .cva6_debug_buf_noc3_valid_o   ( cva6_debug_buf_noc3_valid   ),
+        .buf_cva6_debug_noc3_ready_i   ( buf_cva6_debug_noc3_ready   ),
+        .buf_cva6_bootrom_noc2_data_i  ( buf_cva6_bootrom_noc2_data  ),
+        .buf_cva6_bootrom_noc2_valid_i ( buf_cva6_bootrom_noc2_valid ),
+        .cva6_bootrom_buf_noc2_ready_o ( cva6_bootrom_buf_noc2_ready ),
+        .cva6_bootrom_buf_noc3_data_o  ( cva6_bootrom_buf_noc3_data  ),
+        .cva6_bootrom_buf_noc3_valid_o ( cva6_bootrom_buf_noc3_valid ),
+        .buf_cva6_bootrom_noc3_ready_i ( buf_cva6_bootrom_noc3_ready ),
+        .buf_cva6_clint_noc2_data_i    ( buf_cva6_clint_noc2_data    ),
+        .buf_cva6_clint_noc2_valid_i   ( buf_cva6_clint_noc2_valid   ),
+        .cva6_clint_buf_noc2_ready_o   ( cva6_clint_buf_noc2_ready   ),
+        .cva6_clint_buf_noc3_data_o    ( cva6_clint_buf_noc3_data    ),
+        .cva6_clint_buf_noc3_valid_o   ( cva6_clint_buf_noc3_valid   ),
+        .buf_cva6_clint_noc3_ready_i   ( buf_cva6__clint_noc3_ready   ),
+        .buf_cva6_plic_noc2_data_i     ( buf_cva6_plic_noc2_data     ),
+        .buf_cva6_plic_noc2_valid_i    ( buf_cva6_plic_noc2_valid    ),
+        .cva6_plic_buf_noc2_ready_o    ( cva6_plic_buf_noc2_ready    ),
+        .cva6_plic_buf_noc3_data_o     ( cva6_plic_buf_noc3_data     ),
+        .cva6_plic_buf_noc3_valid_o    ( cva6_plic_buf_noc3_valid    ),
+        .buf_cva6_plic_noc3_ready_i    ( buf_cva6_plic_noc3_ready    ),
         // This selects either the BM or linux bootrom
-        .ariane_boot_sel_i               ( ariane_boot_sel               ),
+        .cva6_boot_sel_i               ( cva6_boot_sel               ),
         // Debug sigs to cores
         .ndmreset_o                      ( ndmreset_o                    ),
         .dmactive_o                      ( dmactive_o                    ),
@@ -1221,21 +1221,21 @@ print str
 `else
 
     // tie off unused sigs
-    assign ariane_debug_buf_noc2_ready   = 1'b0;
-    assign ariane_debug_buf_noc3_data    = `NOC_DATA_WIDTH'b0;
-    assign ariane_debug_buf_noc3_valid   = 1'b0;
+    assign cva6_debug_buf_noc2_ready   = 1'b0;
+    assign cva6_debug_buf_noc3_data    = `NOC_DATA_WIDTH'b0;
+    assign cva6_debug_buf_noc3_valid   = 1'b0;
 
-    assign ariane_bootrom_buf_noc2_ready = 1'b0;
-    assign ariane_bootrom_buf_noc3_data  = `NOC_DATA_WIDTH'b0;
-    assign ariane_bootrom_buf_noc3_valid = 1'b0;
+    assign cva6_bootrom_buf_noc2_ready = 1'b0;
+    assign cva6_bootrom_buf_noc3_data  = `NOC_DATA_WIDTH'b0;
+    assign cva6_bootrom_buf_noc3_valid = 1'b0;
 
-    assign ariane_clint_buf_noc2_ready   = 1'b0;
-    assign ariane_clint_buf_noc3_data    = `NOC_DATA_WIDTH'b0;
-    assign ariane_clint_buf_noc3_valid   = 1'b0;
+    assign cva6_clint_buf_noc2_ready   = 1'b0;
+    assign cva6_clint_buf_noc3_data    = `NOC_DATA_WIDTH'b0;
+    assign cva6_clint_buf_noc3_valid   = 1'b0;
 
-    assign ariane_plic_buf_noc2_ready    = 1'b0;
-    assign ariane_plic_buf_noc3_data     = `NOC_DATA_WIDTH'b0;
-    assign ariane_plic_buf_noc3_valid    = 1'b0;
+    assign cva6_plic_buf_noc2_ready    = 1'b0;
+    assign cva6_plic_buf_noc3_data     = `NOC_DATA_WIDTH'b0;
+    assign cva6_plic_buf_noc3_valid    = 1'b0;
 
 `endif
 

--- a/piton/design/chipset/xilinx/genesys2/devices_ariane.xml
+++ b/piton/design/chipset/xilinx/genesys2/devices_ariane.xml
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 Date: 26.11.2018
-Description: Peripheral address map for OpenPiton+Ariane configurations.
+Description: Peripheral address map for OpenPiton+Cva6 configurations.
 -->
 <devices>
     <!--The first entry should always be the filter/chip to xbar connection-->
@@ -50,35 +50,35 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff0d00000</base>
         <length>0x100000</length>
     </port>
-    <!-- note: the following modules are ariane-specific and are only instantiated in HW when using the ariane core -->
+    <!-- note: the following modules are cva6-specific and are only instantiated in HW when using the cva6 core -->
     <port>
         <!-- this is the shared debug module for JTAG access to all cores -->
-        <name>ariane_debug</name>
+        <name>cva6_debug</name>
         <base>0xfff1000000</base>
         <length>0x1000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- this is the shared bootrom (contains DTB that is generated for the current platform config) -->
-        <name>ariane_bootrom</name>
+        <name>cva6_bootrom</name>
         <base>0xfff1010000</base>
         <length>0x10000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- core local interrupt controller with real-time counter. this is shared among all cores -->
-        <name>ariane_clint</name>
+        <name>cva6_clint</name>
         <base>0xfff1020000</base>
         <length>0xc0000</length>
         <stream_accessible/>
     </port>
     <!-- platform level interrupt controller -->
     <port>
-        <name>ariane_plic</name>
+        <name>cva6_plic</name>
         <base>0xfff1100000</base>
         <length>0x4000000</length>
         <stream_accessible/>
     </port>
-    <!-- end ariane specific periphs -->
+    <!-- end cva6 specific periphs -->
 </devices>
 

--- a/piton/design/chipset/xilinx/vcu118/devices_ariane.xml
+++ b/piton/design/chipset/xilinx/vcu118/devices_ariane.xml
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 Date: 26.11.2018
-Description: Peripheral address map for OpenPiton+Ariane configurations.
+Description: Peripheral address map for OpenPiton+Cva6 configurations.
 -->
 <devices>
     <!--The first entry should always be the filter/chip to xbar connection-->
@@ -49,31 +49,31 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff0d00000</base>
         <length>0x100000</length>
     </port> -->
-    <!-- note: the following modules are ariane-specific and are only instantiated in HW when using the ariane core -->
+    <!-- note: the following modules are cva6-specific and are only instantiated in HW when using the cva6 core -->
     <port>
         <!-- this is the shared debug module for JTAG access to all cores -->
-        <name>ariane_debug</name>
+        <name>cva6_debug</name>
         <base>0xfff1000000</base>
         <length>0x1000</length>
     </port>
     <port>
         <!-- this is the shared bootrom (contains DTB that is generated for the current platform config) -->
-        <name>ariane_bootrom</name>
+        <name>cva6_bootrom</name>
         <base>0xfff1010000</base>
         <length>0x10000</length>
     </port>
     <port>
         <!-- core local interrupt controller with real-time counter. this is shared among all cores -->
-        <name>ariane_clint</name>
+        <name>cva6_clint</name>
         <base>0xfff1020000</base>
         <length>0xc0000</length>
     </port>
     <!-- platform level interrupt controller -->
     <port>
-        <name>ariane_plic</name>
+        <name>cva6_plic</name>
         <base>0xfff1030000</base>
         <length>0x4000000</length>
     </port>
-    <!-- end ariane specific periphs -->
+    <!-- end cva6 specific periphs -->
 </devices>
 

--- a/piton/design/common/rtl/synchronizer.v
+++ b/piton/design/common/rtl/synchronizer.v
@@ -53,7 +53,7 @@ input wire [SIZE-1:0] presyncdata;
 output reg [SIZE-1:0] syncdata;
 
 `ifdef PITON_ARIANE
-// this prevents SV assertion failures in Ariane
+// this prevents SV assertion failures in Cva6
 // pragma translate_off
 `define SIM_RST_INIT
 // pragma translate_on

--- a/piton/design/include/l15.h.pyv
+++ b/piton/design/include/l15.h.pyv
@@ -56,7 +56,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    from pyhplib import *
 
    if 'PITON_ARIANE' in globals():
-       print("// this is used in the ariane SV packages to derive the parameterization")
+       print("// this is used in the Cva6 SV packages to derive the parameterization")
        print("`define CONFIG_L1D_CACHELINE_WIDTH %d"  % 128) # constant at the moment
        print("`define CONFIG_L1I_CACHELINE_WIDTH %d"  % 256) # constant at the moment
        print("`define CONFIG_L15_SIZE %d"             % CONFIG_L15_SIZE)

--- a/piton/design/xilinx/f1/devices_ariane.xml
+++ b/piton/design/xilinx/f1/devices_ariane.xml
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 Date: 26.11.2018
-Description: Peripheral address map for OpenPiton+Ariane configurations.
+Description: Peripheral address map for OpenPiton+Cva6 configurations.
 -->
 <devices>
     <!--The first entry should always be the filter/chip to xbar connection-->
@@ -51,35 +51,35 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff0d00000</base>
         <length>0x100000</length>
     </port>     -->
-    <!-- note: the following modules are ariane-specific and are only instantiated in HW when using the ariane core -->
+    <!-- note: the following modules are cva6-specific and are only instantiated in HW when using the cva6 core -->
     <port>
         <!-- this is the shared debug module for JTAG access to all cores -->
-        <name>ariane_debug</name>
+        <name>cva6_debug</name>
         <base>0xfff1000000</base>
         <length>0x1000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- this is the shared bootrom (contains DTB that is generated for the current platform config) -->
-        <name>ariane_bootrom</name>
+        <name>cva6_bootrom</name>
         <base>0xfff1010000</base>
         <length>0x10000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- core local interrupt controller with real-time counter. this is shared among all cores -->
-        <name>ariane_clint</name>
+        <name>cva6_clint</name>
         <base>0xfff1020000</base>
         <length>0xc0000</length>
         <stream_accessible/>
     </port>
     <!-- platform level interrupt controller -->
     <port>
-        <name>ariane_plic</name>
+        <name>cva6_plic</name>
         <base>0xfff1100000</base>
         <length>0x4000000</length>
         <stream_accessible/>
     </port>
-    <!-- end ariane specific periphs -->
+    <!-- end cva6 specific periphs -->
 </devices>
 

--- a/piton/design/xilinx/genesys2/devices_ariane.xml
+++ b/piton/design/xilinx/genesys2/devices_ariane.xml
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 Date: 26.11.2018
-Description: Peripheral address map for OpenPiton+Ariane configurations.
+Description: Peripheral address map for OpenPiton+Cva6 configurations.
 -->
 <devices>
     <!--The first entry should always be the filter/chip to xbar connection-->
@@ -50,35 +50,35 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff0d00000</base>
         <length>0x100000</length>
     </port>
-    <!-- note: the following modules are ariane-specific and are only instantiated in HW when using the ariane core -->
+    <!-- note: the following modules are cva6-specific and are only instantiated in HW when using the cva6 core -->
     <port>
         <!-- this is the shared debug module for JTAG access to all cores -->
-        <name>ariane_debug</name>
+        <name>cva6_debug</name>
         <base>0xfff1000000</base>
         <length>0x1000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- this is the shared bootrom (contains DTB that is generated for the current platform config) -->
-        <name>ariane_bootrom</name>
+        <name>cva6_bootrom</name>
         <base>0xfff1010000</base>
         <length>0x10000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- core local interrupt controller with real-time counter. this is shared among all cores -->
-        <name>ariane_clint</name>
+        <name>cva6_clint</name>
         <base>0xfff1020000</base>
         <length>0xc0000</length>
         <stream_accessible/>
     </port>
     <!-- platform level interrupt controller -->
     <port>
-        <name>ariane_plic</name>
+        <name>cva6_plic</name>
         <base>0xfff1100000</base>
         <length>0x4000000</length>
         <stream_accessible/>
     </port>
-    <!-- end ariane specific periphs -->
+    <!-- end cva6 specific periphs -->
 </devices>
 

--- a/piton/design/xilinx/nexysVideo/devices_ariane.xml
+++ b/piton/design/xilinx/nexysVideo/devices_ariane.xml
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 Date: 26.11.2018
-Description: Peripheral address map for OpenPiton+Ariane configurations.
+Description: Peripheral address map for OpenPiton+Cva6 configurations.
 -->
 <devices>
     <!--The first entry should always be the filter/chip to xbar connection-->
@@ -50,35 +50,35 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff0d00000</base>
         <length>0x100000</length>
     </port>
-    <!-- note: the following modules are ariane-specific and are only instantiated in HW when using the ariane core -->
+    <!-- note: the following modules are cva6-specific and are only instantiated in HW when using the cva6 core -->
     <port>
         <!-- this is the shared debug module for JTAG access to all cores -->
-        <name>ariane_debug</name>
+        <name>cva6_debug</name>
         <base>0xfff1000000</base>
         <length>0x1000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- this is the shared bootrom (contains DTB that is generated for the current platform config) -->
-        <name>ariane_bootrom</name>
+        <name>cva6_bootrom</name>
         <base>0xfff1010000</base>
         <length>0x10000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- core local interrupt controller with real-time counter. this is shared among all cores -->
-        <name>ariane_clint</name>
+        <name>cva6_clint</name>
         <base>0xfff1020000</base>
         <length>0xc0000</length>
         <stream_accessible/>
     </port>
     <!-- platform level interrupt controller -->
     <port>
-        <name>ariane_plic</name>
+        <name>cva6_plic</name>
         <base>0xfff1100000</base>
         <length>0x4000000</length>
         <stream_accessible/>
     </port>
-    <!-- end ariane specific periphs -->
+    <!-- end cva6 specific periphs -->
 </devices>
 

--- a/piton/design/xilinx/vc707/devices_ariane.xml
+++ b/piton/design/xilinx/vc707/devices_ariane.xml
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 Date: 26.11.2018
-Description: Peripheral address map for OpenPiton+Ariane configurations.
+Description: Peripheral address map for OpenPiton+Cva6 configurations.
 -->
 <devices>
     <!--The first entry should always be the filter/chip to xbar connection-->
@@ -50,35 +50,35 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff0d00000</base>
         <length>0x100000</length>
     </port> -->
-    <!-- note: the following modules are ariane-specific and are only instantiated in HW when using the ariane core -->
+    <!-- note: the following modules are cva6-specific and are only instantiated in HW when using the cva6 core -->
     <port>
         <!-- this is the shared debug module for JTAG access to all cores -->
-        <name>ariane_debug</name>
+        <name>cva6_debug</name>
         <base>0xfff1000000</base>
         <length>0x1000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- this is the shared bootrom (contains DTB that is generated for the current platform config) -->
-        <name>ariane_bootrom</name>
+        <name>cva6_bootrom</name>
         <base>0xfff1010000</base>
         <length>0x10000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- core local interrupt controller with real-time counter. this is shared among all cores -->
-        <name>ariane_clint</name>
+        <name>cva6_clint</name>
         <base>0xfff1020000</base>
         <length>0xc0000</length>
         <stream_accessible/>
     </port>
     <!-- platform level interrupt controller -->
     <port>
-        <name>ariane_plic</name>
+        <name>cva6_plic</name>
         <base>0xfff1100000</base>
         <length>0x4000000</length>
         <stream_accessible/>
     </port>
-    <!-- end ariane specific periphs -->
+    <!-- end cva6 specific periphs -->
 </devices>
 

--- a/piton/design/xilinx/vcu118/devices_ariane.xml
+++ b/piton/design/xilinx/vcu118/devices_ariane.xml
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 Date: 26.11.2018
-Description: Peripheral address map for OpenPiton+Ariane configurations.
+Description: Peripheral address map for OpenPiton+Cva6 configurations.
 -->
 <devices>
     <!--The first entry should always be the filter/chip to xbar connection-->
@@ -50,35 +50,35 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff0d00000</base>
         <length>0x100000</length>
     </port> -->
-    <!-- note: the following modules are ariane-specific and are only instantiated in HW when using the ariane core -->
+    <!-- note: the following modules are cva6-specific and are only instantiated in HW when using the cva6 core -->
     <port>
         <!-- this is the shared debug module for JTAG access to all cores -->
-        <name>ariane_debug</name>
+        <name>cva6_debug</name>
         <base>0xfff1000000</base>
         <length>0x1000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- this is the shared bootrom (contains DTB that is generated for the current platform config) -->
-        <name>ariane_bootrom</name>
+        <name>cva6_bootrom</name>
         <base>0xfff1010000</base>
         <length>0x10000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- core local interrupt controller with real-time counter. this is shared among all cores -->
-        <name>ariane_clint</name>
+        <name>cva6_clint</name>
         <base>0xfff1020000</base>
         <length>0xc0000</length>
         <stream_accessible/>
     </port>
     <!-- platform level interrupt controller -->
     <port>
-        <name>ariane_plic</name>
+        <name>cva6_plic</name>
         <base>0xfff1100000</base>
         <length>0x4000000</length>
         <stream_accessible/>
     </port>
-    <!-- end ariane specific periphs -->
+    <!-- end cva6 specific periphs -->
 </devices>
 

--- a/piton/design/xilinx/xupp3r/devices_ariane.xml
+++ b/piton/design/xilinx/xupp3r/devices_ariane.xml
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 Date: 26.11.2018
-Description: Peripheral address map for OpenPiton+Ariane configurations.
+Description: Peripheral address map for OpenPiton+Cva6 configurations.
 -->
 <devices>
     <!--The first entry should always be the filter/chip to xbar connection-->
@@ -44,35 +44,35 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff0d00000</base>
         <length>0x100000</length>
     </port> -->
-    <!-- note: the following modules are ariane-specific and are only instantiated in HW when using the ariane core -->
+    <!-- note: the following modules are cva6-specific and are only instantiated in HW when using the cva6 core -->
     <port>
         <!-- this is the shared debug module for JTAG access to all cores -->
-        <name>ariane_debug</name>
+        <name>cva6_debug</name>
         <base>0xfff1000000</base>
         <length>0x1000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- this is the shared bootrom (contains DTB that is generated for the current platform config) -->
-        <name>ariane_bootrom</name>
+        <name>cva6_bootrom</name>
         <base>0xfff1010000</base>
         <length>0x10000</length>
         <stream_accessible/>
     </port>
     <port>
         <!-- core local interrupt controller with real-time counter. this is shared among all cores -->
-        <name>ariane_clint</name>
+        <name>cva6_clint</name>
         <base>0xfff1020000</base>
         <length>0xc0000</length>
         <stream_accessible/>
     </port>
     <!-- platform level interrupt controller -->
     <port>
-        <name>ariane_plic</name>
+        <name>cva6_plic</name>
         <base>0xfff1100000</base>
         <length>0x4000000</length>
         <stream_accessible/>
     </port>
-    <!-- end ariane specific periphs -->
+    <!-- end cva6 specific periphs -->
 </devices>
 

--- a/piton/tools/bin/riscvlib.py
+++ b/piton/tools/bin/riscvlib.py
@@ -11,7 +11,7 @@
 #
 # Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 # Date: 04.02.2019
-# Description: Device tree generation script for OpenPiton+Ariane.
+# Description: Device tree generation script for OpenPiton+Cva6.
 
 
 import pyhplib
@@ -24,7 +24,7 @@ def get_bootrom_info(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath,
 
     gitver_cmd = "git log | grep commit -m1 | LD_LIBRARY_PATH= awk -e '{print $2;}'"
     piton_ver  = subprocess.check_output([gitver_cmd], shell=True)
-    ariane_ver = subprocess.check_output(["cd %s && %s" % (dtsPath, gitver_cmd)], shell=True)
+    cva6_ver = subprocess.check_output(["cd %s && %s" % (dtsPath, gitver_cmd)], shell=True)
 
     # get length of memory
     memLen  = 0
@@ -46,16 +46,16 @@ def get_bootrom_info(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath,
         sysFreq = "Unknown"
 
     tmpStr = '''// Info string generated with get_bootrom_info(...)
-// OpenPiton + Ariane framework
+// OpenPiton + Cva6 framework
 // Date: %s
 
 const char info[] = {
 "\\r\\n\\r\\n"
 "----------------------------------------\\r\\n"
-"--     OpenPiton+Ariane Platform      --\\r\\n"
+"--     OpenPiton+Cva6 Platform      --\\r\\n"
 "----------------------------------------\\r\\n"
 "OpenPiton Version: %s                   \\r\\n"
-"Ariane Version:    %s                   \\r\\n"
+"Cva6 Version:    %s                   \\r\\n"
 "                                        \\r\\n"
 "FPGA Board:        %s                   \\r\\n"
 "Build Date:        %s                   \\r\\n"
@@ -76,7 +76,7 @@ const char info[] = {
 
 ''' % (timeStamp,
        piton_ver[0:8],
-       ariane_ver[0:8],
+       cva6_ver[0:8],
        boardName,
        timeStamp,
        int(os.environ['PTON_X_TILES']),
@@ -132,7 +132,7 @@ def gen_riscv_dts(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath, ti
 
 
     tmpStr = '''// DTS generated with gen_riscv_dts(...)
-// OpenPiton + Ariane framework
+// OpenPiton + Cva6 framework
 // Date: %s
 
 /dts-v1/;
@@ -140,8 +140,8 @@ def gen_riscv_dts(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath, ti
 / {
     #address-cells = <2>;
     #size-cells = <2>;
-    compatible = "eth,ariane-bare-dev";
-    model = "eth,ariane-bare";
+    compatible = "eth,cva6-bare-dev";
+    model = "eth,cva6-bare";
     // TODO: interrupt-based UART is currently very slow
     // with this configuration. this needs to be fixed.
     // chosen {
@@ -160,7 +160,7 @@ def gen_riscv_dts(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath, ti
             device_type = "cpu";
             reg = <%d>;
             status = "okay";
-            compatible = "eth, ariane", "riscv";
+            compatible = "eth, cva6", "riscv";
             riscv,isa = "rv64imafdc";
             mmu-type = "riscv,sv39";
             tlb-split;
@@ -194,7 +194,7 @@ def gen_riscv_dts(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath, ti
     soc {
         #address-cells = <2>;
         #size-cells = <2>;
-        compatible = "eth,ariane-bare-soc", "simple-bus";
+        compatible = "eth,cva6-bare-soc", "simple-bus";
         ranges;
     '''
 
@@ -211,7 +211,7 @@ def gen_riscv_dts(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath, ti
     ioDeviceNr=1
     for i in range(len(devices)):
         # CLINT
-        if devices[i]["name"] == "ariane_clint":
+        if devices[i]["name"] == "cva6_clint":
             addrBase = devices[i]["base"]
             addrLen  = devices[i]["length"]
             tmpStr += '''
@@ -226,7 +226,7 @@ def gen_riscv_dts(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath, ti
         };
             ''' % (_reg_fmt(addrBase, addrLen, 2, 2))
         # PLIC
-        if devices[i]["name"] == "ariane_plic":
+        if devices[i]["name"] == "cva6_plic":
             addrBase = devices[i]["base"]
             addrLen  = devices[i]["length"]
             tmpStr += '''
@@ -245,7 +245,7 @@ def gen_riscv_dts(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath, ti
         };
             ''' % (_reg_fmt(addrBase, addrLen, 2, 2), numIrqs)
         # DTM
-        if devices[i]["name"] == "ariane_debug":
+        if devices[i]["name"] == "cva6_debug":
             addrBase = devices[i]["base"]
             addrLen  = devices[i]["length"]
             tmpStr += '''
@@ -327,7 +327,7 @@ def gen_riscv_dts(devices, nCpus, cpuFreq, timeBaseFreq, periphFreq, dtsPath, ti
     # this needs to match
     assert ioDeviceNr-1 == numIrqs
 
-    with open(dtsPath + '/ariane.dts','w') as file:
+    with open(dtsPath + '/cva6.dts','w') as file:
         file.write(tmpStr)
 
 

--- a/piton/tools/src/proto/common/rtl_setup.tcl
+++ b/piton/tools/src/proto/common/rtl_setup.tcl
@@ -523,6 +523,9 @@ set CHIP_RTL_IMPL_FILES [list \
     "${DV_ROOT}/design/chip/tile/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv"                \
     "${DV_ROOT}/design/chip/tile/ariane/src/fpu/src/fpnew_rounding.sv"                              \
     "${DV_ROOT}/design/chip/tile/ariane/src/fpu/src/fpnew_top.sv"                                   \
+    "${DV_ROOT}/design/chip/tile/ariane/src/pmp/src/cva6_pmp.sv"                                    \
+    "${DV_ROOT}/design/chip/tile/ariane/src/pmp/src/cva6_pmp_entry.sv"                              \
+    "${DV_ROOT}/design/chip/tile/ariane/src/pmp/include/cva6_riscv.sv"                              \
 ]
 
 set CHIP_INCLUDE_FILES [list \

--- a/piton/tools/src/proto/common/rtl_setup.tcl
+++ b/piton/tools/src/proto/common/rtl_setup.tcl
@@ -394,20 +394,20 @@ set CHIP_RTL_IMPL_FILES [list \
     "${DV_ROOT}/design/chip/tile/sparc/srams/rtl/sram_wrappers/sram_l1d_tag.v" \
     "${DV_ROOT}/design/chip/tile/sparc/srams/rtl/sram_wrappers/sram_l1i_data.v" \
     "${DV_ROOT}/design/chip/tile/sparc/srams/rtl/sram_wrappers/sram_l1i_tag.v" \
-    "${DV_ROOT}/design/chip/tile/ariane/tb/ariane_soc_pkg.sv"                                 \
+    "${DV_ROOT}/design/chip/tile/ariane/tb/cva6_soc_pkg.sv"                                 \
     "${DV_ROOT}/design/chip/tile/ariane/src/axi/src/axi_pkg.sv"                               \
     "${DV_ROOT}/design/chip/tile/ariane/src/riscv-dbg/src/dm_pkg.sv"                          \
-    "${DV_ROOT}/design/chip/tile/ariane/include/riscv_pkg.sv"                                 \
-    "${DV_ROOT}/design/chip/tile/ariane/include/ariane_pkg.sv"                                \
-    "${DV_ROOT}/design/chip/tile/ariane/include/ariane_axi_pkg.sv"                            \
-    "${DV_ROOT}/design/chip/tile/ariane/include/wt_cache_pkg.sv"                              \
-    "${DV_ROOT}/design/chip/tile/ariane/include/axi_intf.sv"                                  \
+    "${DV_ROOT}/design/chip/tile/ariane/include/cva6_riscv_pkg.sv"                                 \
+    "${DV_ROOT}/design/chip/tile/ariane/include/cva6_pkg.sv"                                \
+    "${DV_ROOT}/design/chip/tile/ariane/include/cva6_axi_pkg.sv"                            \
+    "${DV_ROOT}/design/chip/tile/ariane/include/cva6_wt_cache_pkg.sv"                              \
+    "${DV_ROOT}/design/chip/tile/ariane/include/cva6_axi_intf.sv"                                  \
     "${DV_ROOT}/design/chip/tile/ariane/src/fpu/src/fpnew_pkg.sv"                             \
-    "${DV_ROOT}/design/chip/tile/ariane/src/util/sram.sv"                                     \
-    "${DV_ROOT}/design/chip/tile/ariane/src/util/axi_master_connect.sv"                       \
-    "${DV_ROOT}/design/chip/tile/ariane/src/util/axi_master_connect_rev.sv"                   \
-    "${DV_ROOT}/design/chip/tile/ariane/src/util/axi_slave_connect.sv"                        \
-    "${DV_ROOT}/design/chip/tile/ariane/src/util/axi_slave_connect_rev.sv"                    \
+    "${DV_ROOT}/design/chip/tile/ariane/src/util/cva6_sram.sv"                                     \
+    "${DV_ROOT}/design/chip/tile/ariane/src/util/cva6_axi_master_connect.sv"                       \
+    "${DV_ROOT}/design/chip/tile/ariane/src/util/cva6_axi_master_connect_rev.sv"                   \
+    "${DV_ROOT}/design/chip/tile/ariane/src/util/cva6_axi_slave_connect.sv"                        \
+    "${DV_ROOT}/design/chip/tile/ariane/src/util/cva6_axi_slave_connect_rev.sv"                    \
     "${DV_ROOT}/design/chip/tile/ariane/src/common_cells/src/deprecated/rrarbiter.sv"         \
     "${DV_ROOT}/design/chip/tile/ariane/src/common_cells/src/deprecated/fifo_v1.sv"           \
     "${DV_ROOT}/design/chip/tile/ariane/src/common_cells/src/deprecated/fifo_v2.sv"           \
@@ -426,53 +426,53 @@ set CHIP_RTL_IMPL_FILES [list \
     "${DV_ROOT}/design/chip/tile/ariane/src/tech_cells_generic/src/pulp_clock_gating.sv"      \
     "${DV_ROOT}/design/chip/tile/ariane/src/tech_cells_generic/src/cluster_clock_inverter.sv" \
     "${DV_ROOT}/design/chip/tile/ariane/src/tech_cells_generic/src/pulp_clock_mux2.sv"        \
-    "${DV_ROOT}/design/chip/tile/ariane/src/axi_adapter.sv"                                   \
-    "${DV_ROOT}/design/chip/tile/ariane/src/alu.sv"                                           \
-    "${DV_ROOT}/design/chip/tile/ariane/src/fpu_wrap.sv"                                      \
-    "${DV_ROOT}/design/chip/tile/ariane/src/ariane.sv"                                        \
-    "${DV_ROOT}/design/chip/tile/ariane/src/branch_unit.sv"                                   \
-    "${DV_ROOT}/design/chip/tile/ariane/src/compressed_decoder.sv"                            \
-    "${DV_ROOT}/design/chip/tile/ariane/src/controller.sv"                                    \
-    "${DV_ROOT}/design/chip/tile/ariane/src/csr_buffer.sv"                                    \
-    "${DV_ROOT}/design/chip/tile/ariane/src/csr_regfile.sv"                                   \
-    "${DV_ROOT}/design/chip/tile/ariane/src/decoder.sv"                                       \
-    "${DV_ROOT}/design/chip/tile/ariane/src/ex_stage.sv"                                      \
-    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/btb.sv"                                  \
-    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/bht.sv"                                  \
-    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/ras.sv"                                  \
-    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/instr_scan.sv"                           \
-    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/instr_queue.sv"                          \
-    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/frontend.sv"                             \
-    "${DV_ROOT}/design/chip/tile/ariane/src/id_stage.sv"                                      \
-    "${DV_ROOT}/design/chip/tile/ariane/src/instr_realign.sv"                                 \
-    "${DV_ROOT}/design/chip/tile/ariane/src/issue_read_operands.sv"                           \
-    "${DV_ROOT}/design/chip/tile/ariane/src/issue_stage.sv"                                   \
-    "${DV_ROOT}/design/chip/tile/ariane/src/load_unit.sv"                                     \
-    "${DV_ROOT}/design/chip/tile/ariane/src/load_store_unit.sv"                               \
-    "${DV_ROOT}/design/chip/tile/ariane/src/mmu.sv"                                           \
-    "${DV_ROOT}/design/chip/tile/ariane/src/mult.sv"                                          \
-    "${DV_ROOT}/design/chip/tile/ariane/src/multiplier.sv"                                    \
-    "${DV_ROOT}/design/chip/tile/ariane/src/serdiv.sv"                                        \
-    "${DV_ROOT}/design/chip/tile/ariane/src/perf_counters.sv"                                 \
-    "${DV_ROOT}/design/chip/tile/ariane/src/ptw.sv"                                           \
-    "${DV_ROOT}/design/chip/tile/ariane/src/ariane_regfile_ff.sv"                             \
-    "${DV_ROOT}/design/chip/tile/ariane/src/re_name.sv"                                       \
-    "${DV_ROOT}/design/chip/tile/ariane/src/scoreboard.sv"                                    \
-    "${DV_ROOT}/design/chip/tile/ariane/src/store_buffer.sv"                                  \
-    "${DV_ROOT}/design/chip/tile/ariane/src/amo_buffer.sv"                                    \
-    "${DV_ROOT}/design/chip/tile/ariane/src/store_unit.sv"                                    \
-    "${DV_ROOT}/design/chip/tile/ariane/src/tlb.sv"                                           \
-    "${DV_ROOT}/design/chip/tile/ariane/src/commit_stage.sv"                                  \
-    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/wt_dcache_ctrl.sv"                \
-    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/wt_dcache_mem.sv"                 \
-    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/wt_dcache_missunit.sv"            \
-    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/wt_dcache_wbuffer.sv"             \
-    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/wt_dcache.sv"                     \
-    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/wt_icache.sv"                     \
-    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/wt_l15_adapter.sv"                \
-    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/wt_cache_subsystem.sv"            \
-    "${DV_ROOT}/design/chip/tile/ariane/src/clint/clint.sv"                                   \
-    "${DV_ROOT}/design/chip/tile/ariane/src/clint/axi_lite_interface.sv"                      \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_axi_adapter.sv"                                   \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_alu.sv"                                           \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_fpu_wrap.sv"                                      \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6.sv"                                        \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_branch_unit.sv"                                   \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_compressed_decoder.sv"                            \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_controller.sv"                                    \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_csr_buffer.sv"                                    \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_csr_regfile.sv"                                   \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_decoder.sv"                                       \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_ex_stage.sv"                                      \
+    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/cva6_btb.sv"                                  \
+    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/cva6_bht.sv"                                  \
+    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/cva6_ras.sv"                                  \
+    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/cva6_instr_scan.sv"                           \
+    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/cva6_instr_queue.sv"                          \
+    "${DV_ROOT}/design/chip/tile/ariane/src/frontend/cva6_frontend.sv"                             \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_id_stage.sv"                                      \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_instr_realign.sv"                                 \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_issue_read_operands.sv"                           \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_issue_stage.sv"                                   \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_load_unit.sv"                                     \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_load_store_unit.sv"                               \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_mmu.sv"                                           \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_mult.sv"                                          \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_multiplier.sv"                                    \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_serdiv.sv"                                        \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_perf_counters.sv"                                 \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_ptw.sv"                                           \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_regfile_ff.sv"                             \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_re_name.sv"                                       \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_scoreboard.sv"                                    \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_store_buffer.sv"                                  \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_amo_buffer.sv"                                    \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_store_unit.sv"                                    \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_tlb.sv"                                           \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cva6_commit_stage.sv"                                  \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/cva6_wt_dcache_ctrl.sv"                \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/cva6_wt_dcache_mem.sv"                 \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/cva6_wt_dcache_missunit.sv"            \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/cva6_wt_dcache_wbuffer.sv"             \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/cva6_wt_dcache.sv"                     \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/cva6_wt_icache.sv"                     \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/cva6_wt_l15_adapter.sv"                \
+    "${DV_ROOT}/design/chip/tile/ariane/src/cache_subsystem/cva6_wt_cache_subsystem.sv"            \
+    "${DV_ROOT}/design/chip/tile/ariane/src/clint/cva6_clint.sv"                                   \
+    "${DV_ROOT}/design/chip/tile/ariane/src/clint/cva6_axi_lite_interface.sv"                      \
     "${DV_ROOT}/design/chip/tile/ariane/src/riscv-dbg/debug_rom/debug_rom.sv"                 \
     "${DV_ROOT}/design/chip/tile/ariane/src/riscv-dbg/src/dm_csrs.sv"                         \
     "${DV_ROOT}/design/chip/tile/ariane/src/riscv-dbg/src/dm_mem.sv"                          \
@@ -481,8 +481,8 @@ set CHIP_RTL_IMPL_FILES [list \
     "${DV_ROOT}/design/chip/tile/ariane/src/riscv-dbg/src/dmi_jtag.sv"                        \
     "${DV_ROOT}/design/chip/tile/ariane/src/riscv-dbg/src/dm_sba.sv"                          \
     "${DV_ROOT}/design/chip/tile/ariane/src/riscv-dbg/src/dmi_jtag_tap.sv"                    \
-    "${DV_ROOT}/design/chip/tile/ariane/openpiton/riscv_peripherals.sv"                       \
-    "${DV_ROOT}/design/chip/tile/ariane/openpiton/ariane_verilog_wrap.sv"                     \
+    "${DV_ROOT}/design/chip/tile/ariane/openpiton/cva6_riscv_peripherals.sv"                       \
+    "${DV_ROOT}/design/chip/tile/ariane/openpiton/cva6_verilog_wrap.sv"                     \
     "${DV_ROOT}/design/chip/tile/ariane/openpiton/bootrom/baremetal/bootrom.sv"               \
     "${DV_ROOT}/design/chip/tile/ariane/openpiton/bootrom/linux/bootrom_linux.sv"             \
     "${DV_ROOT}/design/chip/tile/ariane/src/rv_plic/rtl/rv_plic_target.sv"                    \

--- a/piton/tools/src/proto/fpga_lib.py
+++ b/piton/tools/src/proto/fpga_lib.py
@@ -193,13 +193,13 @@ def calcUARTLatch(design_data, board):
 # Name:     isTranslatorOK
 # Input:    addr_data_map   -   addr:data map for a test to check
 #           flog            -   file descriptor for loggin
-#           ariane          -   if true, this will only consider the first
+#           cva6          -   if true, this will only consider the first
 #                               entry. if flase, the first entry will be skipped
 # Output:   True
 # Description: Tests if $DV_ROOT/chipset/rtl/storage_addr_trans.tmp.v
 #              can be used for mapping of addr:map address
 ############################################################################
-def isTranslatorOK(addr_data_map, flog, ariane):
+def isTranslatorOK(addr_data_map, flog, cva6):
     map_loc = DV_ROOT + "/design/chipset/rtl/storage_addr_trans_unified.tmp.v"
     fname = os.path.join(map_loc)
     f = open(fname, 'r')
@@ -209,7 +209,7 @@ def isTranslatorOK(addr_data_map, flog, ariane):
     for line in f:
         m = re.search(r"in_section.*>=\s+64'h([0-9a-fA-F]+).*<\s+64'h([0-9a-fA-F]+)", line)
         if m != None:
-            if ariane:
+            if cva6:
                 if cnt == 0:
                     trans_sections.append((int(m.group(1), 16), int(m.group(2), 16)))
             else:
@@ -270,9 +270,9 @@ def runMidas(tname, uart_div_latch, flog, midas_args=None, coreType="sparc", pre
               -midas_args='-DUART_DIV_LATCH=0x%x -DFPGA_HW -DCIOP -DNO_SLAN_INIT_SPC %s' %s" % \
               (uart_div_latch, midas_args, tname)
 
-    if coreType == "ariane":
+    if coreType == "cva6":
         # specify uart_dmw in order to include load instructions for PASS/FAIL
-        cmd += " -ariane -uart_dmw -x_tiles=%d -y_tiles=%d" % (int(x_tiles), int(y_tiles))
+        cmd += " -cva6 -uart_dmw -x_tiles=%d -y_tiles=%d" % (int(x_tiles), int(y_tiles))
     elif coreType == "sparc":
         # nothing to add at the moment
         pass

--- a/piton/tools/src/proto/pitonstream,1.0
+++ b/piton/tools/src/proto/pitonstream,1.0
@@ -92,7 +92,7 @@ def usage():
     print >> sys.stderr, "\n       -c, --core <core_config>"
     print >> sys.stderr, "              Name of a supported core configuration:"
     print >> sys.stderr, "                  sparc     (opensparc T1 core, default)"
-    print >> sys.stderr, "                  ariane    (64bit RISCV core)"
+    print >> sys.stderr, "                  cva6    (64bit RISCV core)"
     print >> sys.stderr, "\n       -f, --file <filename>"
     print >> sys.stderr, "              File name with test names. If option --ustr is not specified,"
     print >> sys.stderr, "              they should be assembly test names, otherwise list of generated"
@@ -304,7 +304,7 @@ def compileASMTest(tname, uart_div_latch, st_brd, flog, midas_args=None, coreTyp
 
     # Since we are using an existent synthesized mapping, we have to check
     # that all sections of new tests are mapped
-    rv = isTranslatorOK(addr_data_map, flog, coreType=="ariane")
+    rv = isTranslatorOK(addr_data_map, flog, coreType=="cva6")
     if not rv:
         print_error("Can't use existent storage_addr_trans.tmp.v for %s" % tname)
         return 1
@@ -400,8 +400,8 @@ def main():
     for tname in tests:
         test_cnt += 1
         print_info("Running %s: %d out of %d test" % (tname, test_cnt, test_num))
-        if options.precompiled and options.core == "Ariane":
-            print_info("Using precompiled RISCV test for Ariane.")
+        if options.precompiled and options.core == "Cva6":
+            print_info("Using precompiled RISCV test for Cva6.")
         # Compile .s tests to get .ustr
         if options.ustr == False:
             rv = compileASMTest(tname, uart_div_latch, st_brd, flog, options.midas_args, options.core, options.precompiled, options.x_tiles, options.y_tiles)

--- a/piton/tools/src/proto/pitonunimap,1.0
+++ b/piton/tools/src/proto/pitonunimap,1.0
@@ -60,7 +60,7 @@ def usage():
     print >> sys.stderr, "\n       -c, --core <core_config>"
     print >> sys.stderr, "              Name of a supported core configuration:"
     print >> sys.stderr, "                  sparc     (opensparc T1 core, default)"
-    print >> sys.stderr, "                  ariane    (64bit RISCV core)"
+    print >> sys.stderr, "                  cva6    (64bit RISCV core)"
     print >> sys.stderr, "\n       -h, --help"
     print >> sys.stderr, "              Display this help message"
     print >> sys.stderr, "\n"

--- a/piton/tools/src/proto/protosyn,2.5
+++ b/piton/tools/src/proto/protosyn,2.5
@@ -73,7 +73,7 @@ def usage():
     print >> sys.stderr, "                  sparc     (opensparc T1 core, default)"
     print >> sys.stderr, "                  pico      (32bit RISCV core)"
     print >> sys.stderr, "                  pico_het  (heterogeneous pico+sparc arrangement)"
-    print >> sys.stderr, "                  ariane    (64bit RISCV core)"
+    print >> sys.stderr, "                  cva6    (64bit RISCV core)"
     print >> sys.stderr, "\n       --network_config <network_config>"
     print >> sys.stderr, "              Name of the network type to be used:"
     print >> sys.stderr, "                  2dmesh_config (default)"
@@ -487,7 +487,7 @@ def makeDefList(options):
     #defines.append(df)
 
     # disable CSM in this case
-    if options.core == 'ariane':
+    if options.core == 'cva6':
         defines.append("NO_RTL_CSM")
 
     if (options.board == "f1"):
@@ -749,7 +749,7 @@ def main():
                 os.environ['RTL_SPARC' + str(i)] = "1"
                 print_info('setenv RTL_SPARC' + str(i))
 
-    elif options.core == 'ariane':
+    elif options.core == 'cva6':
         os.environ['PITON_ARIANE'] = "1"
         os.environ['WT_DCACHE']    = "1"
 
@@ -829,8 +829,8 @@ def main():
         if options.core == 'pico_het':
             config += ' -pico -pico_het'
 
-        if options.core == 'ariane':
-            config += ' -ariane'
+        if options.core == 'cva6':
+            config += ' -cva6'
 
         print_info("Synthesizing a test: %s" % options.test_name)
         print_info("Compilation started")

--- a/piton/tools/src/sims/sims,2.0
+++ b/piton/tools/src/sims/sims,2.0
@@ -171,7 +171,7 @@ Getopt::Long::Configure ('no_auto_abbrev') ;
         'overwrite' => 0,
         'pal_use_tgseed' => 0,
         'parallel' => 0,
-        'ariane' => 0,
+        'cva6' => 0,
         'pico' => 0,
         'pico_het' => 0,
         'post_process_cmd' => [],
@@ -321,7 +321,7 @@ GetOptions (\%opt,
             'group=s@',
             'model_dir=s',
             'parallel!',
-            'ariane!',
+            'cva6!',
             'pico!',
             'pico_het!',
             'regress!',
@@ -1090,8 +1090,8 @@ sub gen_flist
 
   # Add ORAM flist if ORAM is specified
   push (@{$opt{flist}}, "$ENV{DV_ROOT}/design/chip/tinyoram/rtl/Flist.oram") if ($opt{oram}) ;
-  # Add Ariane flist if -ariane is specified
-  push (@{$opt{flist}}, "$ENV{DV_ROOT}/design/chip/tile/ariane/Flist.ariane") if ($opt{ariane}) ;
+  # Add Cva6 flist if -cva6 is specified
+  push (@{$opt{flist}}, "$ENV{DV_ROOT}/design/chip/tile/ariane/Flist.cva6") if ($opt{cva6}) ;
 
 
   foreach my $flist (@{$opt{flist}}) {
@@ -1251,20 +1251,20 @@ sub pre_build
 
   system("cp -f flist $cur_dir");
 
-  if($opt{ariane}) {
-    print "compiling DTS and bootroms for Ariane...\n";
+  if($opt{cva6}) {
+    print "compiling DTS and bootroms for Cva6...\n";
     !system("cd $ENV{ARIANE_ROOT}/openpiton/bootrom/baremetal && make clean && make all && cd - > /dev/null") or
-      die (" Error compiling DTS for ariane.");
+      die (" Error compiling DTS for cva6.");
     !system("cd $ENV{ARIANE_ROOT}/openpiton/bootrom/linux && make clean && make all MAX_HARTS=$ENV{PTON_NUM_TILES} && cd - > /dev/null") or
-      die (" Error compiling DTS for ariane.");
+      die (" Error compiling DTS for cva6.");
     print "done\n";
     # currently we have two sources (hardcoded in chipset_impl): UART and Ethernet
     my $num_sources = 2;
     # 2 targets per core (M/S mode)
     my $num_targets = 2 * $ENV{PTON_NUM_TILES};
-    print "generating PLIC for Ariane with $num_targets targets and $num_sources sources...\n";
+    print "generating PLIC for Cva6 with $num_targets targets and $num_sources sources...\n";
     !system("cd $ENV{ARIANE_ROOT}/src/rv_plic/rtl && ./gen_plic_addrmap.py -t $num_targets -s $num_sources > plic_regmap.sv") or
-      die (" Error generating PLIC for Ariane.");
+      die (" Error generating PLIC for Cva6.");
     print "done\n";
   }
 
@@ -1356,7 +1356,7 @@ sub generic_sim_build
       push (@{$opt{vcs_build_args}}, "-l compile.log") ;
 
       # some SystemVerilog-specific options
-      if ($opt{ariane}) {
+      if ($opt{cva6}) {
           push (@{$opt{vcs_build_args}}, "-sverilog +systemverilogext+.sv") ;
           push (@{$opt{vcs_build_args}}, "-ntb_opts uvm-1.1 +vpi ") ;
       }
@@ -1484,8 +1484,8 @@ sub generic_sim_build
       # lib_path needs to be before vcs_build_args
       $build_cmd .= $lib_path;
 
-      # the ariane files do not contain the timescale
-      if ($opt{ariane}) {
+      # the cva6 files do not contain the timescale
+      if ($opt{cva6}) {
         $build_cmd .= " -timescale=1ps/1ps ";
       }
     }
@@ -2195,8 +2195,8 @@ sub assemble_diag
     `rm -rf diag.pal diag.s diag.S diag.pl diag.exe mem.image diag.ev symbol.tbl` ;
     die "DIE. could not clean up assembly diag run area"  if ($?) ;
 
-    # add default path to look for precompiled RISCV 64bit assembly tests diags in case of ariane
-    if ($opt{ariane} and $opt{precompiled}) {
+    # add default path to look for precompiled RISCV 64bit assembly tests diags in case of cva6
+    if ($opt{cva6} and $opt{precompiled}) {
       push @{$opt{asm_diag_root}}, "$ENV{ARIANE_ROOT}/tmp/riscv-tests/build/isa";
       push @{$opt{asm_diag_root}}, "$ENV{ARIANE_ROOT}/tmp/riscv-tests/build/benchmarks";
     }
@@ -2207,9 +2207,9 @@ sub assemble_diag
     my $diag_name ;
     if ($opt{asm_diag_name} =~ /\.pal/)        { $diag_name = "diag.pal"  ; }
     elsif ($opt{asm_diag_name} =~ /\.s\.gz/)   { $diag_name = "diag.s.gz" ; }
-    elsif ($opt{precompiled} and $opt{ariane}) { $diag_name = "diag.exe"  ; }
-    elsif (($opt{pico} | $opt{ariane}) and ($opt{asm_diag_name} =~ /\.S/)) { $diag_name = "diag.S" ; }
-    elsif (($opt{pico} | $opt{ariane}) and ($opt{asm_diag_name} =~ /\.c/)) { $diag_name = "diag.c" ; }
+    elsif ($opt{precompiled} and $opt{cva6}) { $diag_name = "diag.exe"  ; }
+    elsif (($opt{pico} | $opt{cva6}) and ($opt{asm_diag_name} =~ /\.S/)) { $diag_name = "diag.S" ; }
+    elsif (($opt{pico} | $opt{cva6}) and ($opt{asm_diag_name} =~ /\.c/)) { $diag_name = "diag.c" ; }
     else { $diag_name = "diag.s" ; }
 
     # copy diagnostic to run area
@@ -2260,8 +2260,8 @@ sub assemble_diag
       my $waitstatus = call_program($cmd, "rv32_as.log");
       die ("DIE. rv32_as compilation error") if ($waitstatus) ;
 
-    } elsif ($opt{ariane}) {
-      # RISCV flow for RV64IMAC (ARIANE from PULP)
+    } elsif ($opt{cva6}) {
+      # RISCV flow for RV64IMAC (CVA6 from PULP)
       # only recompile if necessary
       if (!$opt{precompiled}) {
         print "$prg: assembling 64bit riscv diag (RV64IMAC)\n" ;
@@ -2648,8 +2648,8 @@ sub parse_args
     else { die ("DIE. Unprocessed argument: $x") ; }
   }
 
-  # in case a precompiled riscv binary for ariane is directly specified
-  if ($opt{precompiled} and $opt{ariane}) {
+  # in case a precompiled riscv binary for cva6 is directly specified
+  if ($opt{precompiled} and $opt{cva6}) {
     if (!($opt{asm_diag_name} =~ /\.riscv/)) {
         $opt{asm_diag_name} = fileparse($opt{asm_diag_name}, qr/\.[^.]*/);
     }
@@ -2707,18 +2707,18 @@ sub parse_args
     $ENV{PTON_NETWORK_CONFIG}="2d_mesh";
   }
 
-  die ("DIE. -ariane and -pico/-pico_het cannot be set simultaneously") if ($opt{ariane} && ($opt{pico} || $opt{pico_het})) ;
+  die ("DIE. -cva6 and -pico/-pico_het cannot be set simultaneously") if ($opt{cva6} && ($opt{pico} || $opt{pico_het})) ;
   die ("DIE. -pico and -pico_het cannot both be set") if ($opt{pico} && $opt{pico_het}) ;
   $ENV{PITON_PICO}     = $opt{pico};
   $ENV{PITON_PICO_HET} = $opt{pico_het};
-  $ENV{PITON_ARIANE}   = $opt{ariane};
+  $ENV{PITON_ARIANE}   = $opt{cva6};
   push (@{$opt{config_rtl}}, "PITON_PICO")     if ($opt{pico});
   push (@{$opt{config_rtl}}, "PITON_PICO_HET") if ($opt{pico_het});
-  push (@{$opt{config_rtl}}, "PITON_ARIANE")   if ($opt{ariane});
-  push (@{$opt{config_rtl}}, "WT_DCACHE")      if ($opt{ariane});
+  push (@{$opt{config_rtl}}, "PITON_ARIANE")   if ($opt{cva6});
+  push (@{$opt{config_rtl}}, "WT_DCACHE")      if ($opt{cva6});
 
 
-  if ($opt{pico} or $opt{pico_het} or $opt{ariane}) {
+  if ($opt{pico} or $opt{pico_het} or $opt{cva6}) {
     push (@{$opt{config_rtl}}, "NO_MRA_VAL") ;
     push (@{$opt{config_rtl}}, "NO_SLAM_RANDOM") ;
   }
@@ -2750,7 +2750,7 @@ sub parse_args
   for (my $i=0; $i < $pton_num_tiles; $i++) {
     if ($opt{pico} || ($opt{pico_het} && ($i % 2 == 1))) {
         push (@{$opt{config_rtl}}, "RTL_PICO" . $i);
-    } elsif ($opt{ariane}) {
+    } elsif ($opt{cva6}) {
         push (@{$opt{config_rtl}}, "RTL_ARIANE" . $i);
     } else {
         push (@{$opt{config_rtl}}, "RTL_SPARC" . $i);
@@ -3038,8 +3038,8 @@ VERILOG COMPILATION RELATED
            this specifies that a heterogeneous arrangement with OpenSPARC and PICORV32 shall be built,
            where every odd core is a PICORV32 core (along the x-dimension).
 
-    -ariane
-           this specifies that the ARIANE RV64GC core shall be used instead of OpenSPARC.
+    -cva6
+           this specifies that the CVA6 RV64GC core shall be used instead of OpenSPARC.
            in this case, programs are compiled and assembled using the RISCV GCC toolchain.
 
 VERILOG RUNTIME RELATED
@@ -3095,7 +3095,7 @@ midas is the diag assembler
 
 RISCV GCC
 
-this is the compiler used for RISC-V cores (e.g., when the -pico or -ariane switches are specified).
+this is the compiler used for RISC-V cores (e.g., when the -pico or -cva6 switches are specified).
 
     -uart_dmw
            use this switch when compiling code for Pitonstream. this will add load

--- a/piton/tools/src/tursi/tursi,1.0
+++ b/piton/tools/src/tursi/tursi,1.0
@@ -106,7 +106,7 @@ See $DV_ROOT/tools/src/proto/block.list for supported design modules"""
     core_choices={"sparc"   : "(opensparc T1 core, default)",
                   "pico"    : "(32bit RISCV core)",
                   "pico_het": "(heterogeneous pico+sparc arrangement)",
-                  "ariane"  : "(64bit RISCV core)"}
+                  "cva6"  : "(64bit RISCV core)"}
     core_help_str = \
 """Name of a supported core configurations (default: %(default)s):
 {}""".format("\n".join("\t* {} : {}".format(key,val) for key, val in core_choices.items()))
@@ -444,11 +444,11 @@ def main():
                 args.config_rtl.append('RTL_SPARC' + str(i))
                 print_info('defining RTL_SPARC' + str(i))
 
-    elif args.core == 'ariane':
+    elif args.core == 'cva6':
         args.config_rtl.append('PITON_ARIANE')
 
         ## Temporary until we create a solution for SystemVerilog code
-        print_error('Due to lack of support for "pickling" of SystemVerilog code, the Ariane core configuration option is not supported')
+        print_error('Due to lack of support for "pickling" of SystemVerilog code, the Cva6 core configuration option is not supported')
         sys.exit(1)
 
         for i in range(int(args.num_tiles)):

--- a/piton/verif/diag/master_diaglist_princeton
+++ b/piton/verif/diag/master_diaglist_princeton
@@ -87,7 +87,7 @@ pico-amoxor     amoxor_w.S
 </pico_tile1>
 
 
-<ariane_tile1 sys=manycore -x_tiles=1 -y_tiles=1 -ariane>
+<cva6_tile1 sys=manycore -x_tiles=1 -y_tiles=1 -cva6>
 <cmp_default name=default>
     // note: these asm tests assume that the RISCV tests have been precompiled with the
     // correct environment

--- a/piton/verif/env/manycore/cross_module.h.pyv
+++ b/piton/verif/env/manycore/cross_module.h.pyv
@@ -99,14 +99,14 @@
 for i in range(NUM_TILES):
     printstring = """
     `define TILE%d            `CHIP.tile%d
-    `define ARIANE_CORE%d     `TILE%d.g_ariane_core.core.ariane
+    `define ARIANE_CORE%d     `TILE%d.g_cva6_core.core.cva6
     `define SPARC_CORE%d      `TILE%d.g_sparc_core.core
     `define PICO_CORE%d       `TILE%d.g_picorv32_core.core
     `ifdef RTL_SPARC%d
     `define CORE_REF%d        `SPARC_CORE%d
     `endif // ifdef RTL_SPARC%d
     `ifdef RTL_ARIANE%d
-    `define CORE_REF%d        `TILE%d.g_ariane_core.core
+    `define CORE_REF%d        `TILE%d.g_cva6_core.core
     `endif // ifdef RTL_ARIANE%d
     `ifdef RTL_PICO%d
     `define CORE_REF%d        `PICO_CORE%d

--- a/piton/verif/env/manycore/devices_ariane.xml
+++ b/piton/verif/env/manycore/devices_ariane.xml
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
 Date: 26.11.2018
-Description: Peripheral address map for OpenPiton+Ariane configurations.
+Description: Peripheral address map for OpenPiton+Cva6 configurations.
 -->
 <devices>
     <!--The first entry should always be the filter/chip to xbar connection-->
@@ -43,30 +43,30 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff0d00000</base>
         <length>0x100000</length>
     </port> -->
-    <!-- note: the following modules are ariane-specific and are only instantiated in HW when using the ariane core -->
+    <!-- note: the following modules are cva6-specific and are only instantiated in HW when using the cva6 core -->
     <port>
         <!-- this is the shared debug module for JTAG access to all cores -->
-        <name>ariane_debug</name>
+        <name>cva6_debug</name>
         <base>0xfff1000000</base>
         <length>0x1000</length>
     </port>
     <port>
         <!-- this is the shared bootrom (contains DTB that is generated for the current platform config) -->
-        <name>ariane_bootrom</name>
+        <name>cva6_bootrom</name>
         <base>0xfff1010000</base>
         <length>0x10000</length>
     </port>
     <port>
         <!-- core local interrupt controller with real-time counter. this is shared among all cores -->
-        <name>ariane_clint</name>
+        <name>cva6_clint</name>
         <base>0xfff1020000</base>
         <length>0xc0000</length>
     </port>
     <!-- platform level interrupt controller -->
     <port>
-        <name>ariane_plic</name>
+        <name>cva6_plic</name>
         <base>0xfff1100000</base>
         <length>0x4000000</length>
     </port>
-    <!-- end ariane specific periphs -->
+    <!-- end cva6 specific periphs -->
 </devices>


### PR DESCRIPTION
Hello, as we refer in https://github.com/openhwgroup/cva6/pull/485 , I have edited the openpiton. 
Now, the work flow
`source piton/ariane_setup.sh`
`protosyn -b genesys2 -d system --core=cva6 --uart-dmw ddr`
can finish without error.

By the way, new feature `pmp` was added into ariane recently, and I add the file list in the second commit.