### PR TITLE
update setup.tcl for newer vivado versions

### DIFF
--- a/piton/tools/src/proto/common/setup.tcl
+++ b/piton/tools/src/proto/common/setup.tcl
@@ -121,6 +121,9 @@ set ALL_INCLUDE_FILES [pyhp_preprocess ${ALL_INCLUDE_FILES}]
 if  {[info exists ::env(PITON_ARIANE)]} {
   puts "INFO: compiling DTS and bootroms for Ariane (MAX_HARTS=$::env(PITON_NUM_TILES), UART_FREQ=$env(CONFIG_SYS_FREQ))..."
   
+  
+  # credit goes to https://github.com/PrincetonUniversity/openpiton/issues/50 
+  # and https://www.xilinx.com/support/answers/72570.html
   set tmp_PYTHONPATH $env(PYTHONPATH)                                                                               
   set tmp_PYTHONHOME $env(PYTHONHOME)                                                                               
   unset ::env(PYTHONPATH)                                                                                           

--- a/piton/tools/src/proto/common/setup.tcl
+++ b/piton/tools/src/proto/common/setup.tcl
@@ -120,6 +120,12 @@ set ALL_INCLUDE_FILES [pyhp_preprocess ${ALL_INCLUDE_FILES}]
 
 if  {[info exists ::env(PITON_ARIANE)]} {
   puts "INFO: compiling DTS and bootroms for Ariane (MAX_HARTS=$::env(PITON_NUM_TILES), UART_FREQ=$env(CONFIG_SYS_FREQ))..."
+  
+  set tmp_PYTHONPATH $env(PYTHONPATH)                                                                               
+  set tmp_PYTHONHOME $env(PYTHONHOME)                                                                               
+  unset ::env(PYTHONPATH)                                                                                           
+  unset ::env(PYTHONHOME)
+  
   set TMP [pwd]
   cd $::env(ARIANE_ROOT)/openpiton/bootrom/baremetal
   # Note: dd dumps info to stderr that we do not want to interpret
@@ -141,5 +147,7 @@ if  {[info exists ::env(PITON_ARIANE)]} {
 
   cd $TMP
   puts "INFO: done"
+  set ::env(PYTHONPATH) $tmp_PYTHONPATH                                                                           
+  set ::env(PYTHONHOME) $tmp_PYTHONHOME 
 }
 


### PR DESCRIPTION
update setup.tcl to prevent python version conflicts for Vivado version > 2019.1
See this AR for detail https://www.xilinx.com/support/answers/72570.html
address issue #50 