### PR TITLE
Minor cleanup

### DIFF
--- a/piton/design/chipset/mc/rtl/noc_mig_bridge.v
+++ b/piton/design/chipset/mc/rtl/noc_mig_bridge.v
@@ -549,7 +549,7 @@ assign app_addr_virt = pkt_w2[buf_current_cmd][`MSG_ADDR_];
   storage_addr_trans #(
 `endif
     .STORAGE_ADDR_WIDTH(`MIG_APP_ADDR_WIDTH)
-  ) cpu_mig_addr_translastor (
+  ) cpu_mig_addr_translator (
     .va_byte_addr       (app_addr_virt        ),
     .storage_addr_out   (storage_addr_out     )
   );

--- a/piton/design/chipset/noc_axi4_bridge/rtl/noc_axi4_bridge_read.v
+++ b/piton/design/chipset/noc_axi4_bridge/rtl/noc_axi4_bridge_read.v
@@ -145,7 +145,7 @@ storage_addr_trans_unified   #(
 storage_addr_trans #(
 `endif
 .STORAGE_ADDR_WIDTH(`AXI4_ADDR_WIDTH)
-) cpu_mig_waddr_translastor (
+) cpu_mig_waddr_translator (
     .va_byte_addr       (virt_addr  ),
     .storage_addr_out   (phys_addr  )
 );

--- a/piton/design/chipset/noc_axi4_bridge/rtl/noc_axi4_bridge_write.v
+++ b/piton/design/chipset/noc_axi4_bridge/rtl/noc_axi4_bridge_write.v
@@ -183,7 +183,7 @@ storage_addr_trans_unified   #(
 storage_addr_trans #(
 `endif
 .STORAGE_ADDR_WIDTH(`AXI4_ADDR_WIDTH)
-) cpu_mig_raddr_translastor (
+) cpu_mig_raddr_translator (
     .va_byte_addr       (virt_addr  ),
     .storage_addr_out   (phys_addr  )
 );

--- a/piton/design/chipset/noc_axi4_bridge/rtl/noc_axi4_bridge_write.v
+++ b/piton/design/chipset/noc_axi4_bridge/rtl/noc_axi4_bridge_write.v
@@ -174,7 +174,7 @@ assign m_axi_wid = {{`AXI4_ID_WIDTH-`NOC_AXI4_BRIDGE_BUFFER_ADDR_SIZE{1'b0}}, re
 wire [`PHY_ADDR_WIDTH-1:0] virt_addr = req_header_f[`MSG_ADDR];
 wire [`AXI4_ADDR_WIDTH-1:0] phys_addr;
 wire uncacheable = (virt_addr[`PHY_ADDR_WIDTH-1])
-                || (req_header_f[`MSG_TYPE] == `MSG_TYPE_NC_STORE_REQ);;
+                || (req_header_f[`MSG_TYPE] == `MSG_TYPE_NC_STORE_REQ);
 
 // If running uart tests - we need to do address translation
 `ifdef PITONSYS_UART_BOOT

--- a/piton/design/fpga_tests/memio_unit_tests/memctrl_test/rtl/memctrl_test.v
+++ b/piton/design/fpga_tests/memio_unit_tests/memctrl_test/rtl/memctrl_test.v
@@ -226,7 +226,7 @@ begin
         end
         3'd1:
         begin
-            addr_incr_val = {{`PHY_ADDR_WIDTH-7{1'b0}}, 7'd1};;
+            addr_incr_val = {{`PHY_ADDR_WIDTH-7{1'b0}}, 7'd1};
             data_payload_flits = 8'd1;
             mem_top_addr = {{`PHY_ADDR_WIDTH-MEMSIZE_BYTES_LOG2{1'b0}}, {MEMSIZE_BYTES_LOG2{1'b1}}};
         end


### PR DESCRIPTION
* Rename `translastor` to `translator`.
* Remove stray semicolons, which QuestaSim 2020.4 does not like in Verilog code.