### PR TITLE
Potential problem with L2P1 msg_data consumption

### DIFF
--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -2214,7 +2214,7 @@ end
 
 always @(*) begin
     msg_data_pending = 1'b0;
-    if (msg_carrying_data_S2_f && !msg_data_ready_S2) begin
+    if (valid_S2 && msg_carrying_data_S2_f && !msg_data_ready_S2) begin
         if (cs_S2[`CS_MSHR_WR_EN_P1S2]) begin
             // CAUTION: We assume that after a request reads msg_data, it would not get into mshr again.
             msg_data_pending = 1'b1;
@@ -2226,7 +2226,7 @@ always @(posedge clk) begin
     if (~rst_n) begin
         msg_data_pending_f <= 1'b0;
     end
-    else if (msg_carrying_data_S2_f && !msg_data_ready_S2) begin
+    else if (valid_S2 && msg_carrying_data_S2_f && !msg_data_ready_S2) begin
         if (cs_S2[`CS_MSHR_WR_EN_P1S2]) begin
             msg_data_pending_f <= 1'b1;
         end

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -345,6 +345,8 @@ reg [`MSG_TYPE_WIDTH-1:0] msg_type_S2_f;
 reg msg_from_mshr_S2_f;
 reg [`MSG_TYPE_WIDTH-1:0] msg_type_S4_f;
 
+reg msg_data_pending, msg_data_pending_f;
+
 //============================
 // Stage 1
 //============================
@@ -932,15 +934,40 @@ begin
 end
 
 reg stall_msg_S1;
+reg stall_msg_data_S1;
 
 always @ *
 begin
     stall_msg_S1 = msg_data_rd_S1 && ~msg_data_valid_S1;
 end
 
+wire msg_carrying_data_S1 = (msg_data_16B_amo_S2_f && ((msg_type_S2_f == `MSG_TYPE_SWAP_P1_REQ) || (msg_type_S2_f == `MSG_TYPE_SWAPWB_P1_REQ))) ||
+                              (msg_type_S2_f == `MSG_TYPE_CAS_P2Y_REQ    ) ||
+                              (msg_type_S2_f == `MSG_TYPE_SWAP_P2_REQ    ) ||
+                              (msg_type_S2_f == `MSG_TYPE_SWAPWB_P2_REQ  ) ||
+                              (msg_type_S2_f == `MSG_TYPE_AMO_ADD_P2_REQ ) ||
+                              (msg_type_S2_f == `MSG_TYPE_AMO_AND_P2_REQ ) ||
+                              (msg_type_S2_f == `MSG_TYPE_AMO_OR_P2_REQ  ) ||
+                              (msg_type_S2_f == `MSG_TYPE_AMO_XOR_P2_REQ ) ||
+                              (msg_type_S2_f == `MSG_TYPE_AMO_MAX_P2_REQ ) ||
+                              (msg_type_S2_f == `MSG_TYPE_AMO_MAXU_P2_REQ) ||
+                              (msg_type_S2_f == `MSG_TYPE_AMO_MIN_P2_REQ ) ||
+                              (msg_type_S2_f == `MSG_TYPE_AMO_MINU_P2_REQ) ||
+                              (msg_type_S2_f == `MSG_TYPE_NC_STORE_REQ) ||
+                              (msg_type_S2_f == `MSG_TYPE_CAS_P1_REQ) ||
+                              (msg_type_S2_f == `MSG_TYPE_CAS_P2N_REQ) || (msg_type_S2_f == `MSG_TYPE_INTERRUPT_FWD);
+always @(*) begin
+    // This is a pretty conservative stall, but we actually won't have many cases with msg_data_pending.
+    // For requests that carries msg_data (nc_store, atomic), they might get into mshr. In this case,
+    // msg_data_val would be high for a long time, until that request come back from mshr and raise 
+    // msg_data_ready. During this period, if another request carrying data arrives, it will read the 
+    // wrong data. To prevent this, we simply stop accepting new request until msg_data_pending is resolved.
+    stall_msg_data_S1 = (msg_data_pending || msg_data_pending_f) && msg_carrying_data_S1 && !msg_from_mshr_S1;
+end
+
 always @ *
 begin
-    stall_S1 = valid_S1 && (stall_pre_S1 || stall_hazard_S1 || stall_mshr_S1 || stall_msg_S1);
+    stall_S1 = valid_S1 && (stall_pre_S1 || stall_hazard_S1 || stall_mshr_S1 || stall_msg_S1 || stall_msg_data_S1);
 end
 
 
@@ -1029,6 +1056,7 @@ reg mshr_smc_miss_S2_f;
 reg [`L2_MSHR_INDEX_WIDTH-1:0] mshr_pending_index_S2_f;
 reg special_addr_type_S2_f;
 reg msg_data_rd_S2_f;
+reg msg_carrying_data_S2_f;
 
 always @ (posedge clk)
 begin
@@ -1047,6 +1075,7 @@ begin
         special_addr_type_S2_f <= 0;
         msg_data_rd_S2_f <= 0;
         amo_alu_op_S2_f <= `L2_AMO_ALU_OP_WIDTH'b0;
+        msg_carrying_data_S2_f <= 1'b0;
     end
     else if (!stall_S2)
     begin
@@ -1067,6 +1096,7 @@ begin
         special_addr_type_S2_f <= special_addr_type_S1;
         msg_data_rd_S2_f <= msg_data_rd_S1;
         amo_alu_op_S2_f <= amo_alu_op_S1;
+        msg_carrying_data_S2_f <= msg_carrying_data_S1;
     end
 end
 
@@ -2180,6 +2210,30 @@ end
 always @ *
 begin
     msg_data_ready_S2 = valid_S2 && !stall_S2 && (cs_S2[`CS_STATE_DATA_RDY_P1S2] || msg_data_rd_S2_f);
+end
+
+always @(*) begin
+    msg_data_pending = 1'b0;
+    if (msg_carrying_data_S2_f && !msg_data_ready_S2) begin
+        if (cs_S2[`CS_MSHR_WR_EN_P1S2]) begin
+            // CAUTION: We assume that after a request reads msg_data, it would not get into mshr again.
+            msg_data_pending = 1'b1;
+        end
+    end
+end
+
+always @(posedge clk) begin
+    if (~rst_n) begin
+        msg_data_pending_f <= 1'b0;
+    end
+    else if (msg_carrying_data_S2_f && !msg_data_ready_S2) begin
+        if (cs_S2[`CS_MSHR_WR_EN_P1S2]) begin
+            msg_data_pending_f <= 1'b1;
+        end
+    end
+    else if (msg_data_ready_S2 && msg_data_valid_S2) begin
+        msg_data_pending_f <= 1'b0;
+    end
 end
 
 

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -941,21 +941,21 @@ begin
     stall_msg_S1 = msg_data_rd_S1 && ~msg_data_valid_S1;
 end
 
-wire msg_carrying_data_S1 = (msg_data_16B_amo_S2_f && ((msg_type_S2_f == `MSG_TYPE_SWAP_P1_REQ) || (msg_type_S2_f == `MSG_TYPE_SWAPWB_P1_REQ))) ||
-                              (msg_type_S2_f == `MSG_TYPE_CAS_P2Y_REQ    ) ||
-                              (msg_type_S2_f == `MSG_TYPE_SWAP_P2_REQ    ) ||
-                              (msg_type_S2_f == `MSG_TYPE_SWAPWB_P2_REQ  ) ||
-                              (msg_type_S2_f == `MSG_TYPE_AMO_ADD_P2_REQ ) ||
-                              (msg_type_S2_f == `MSG_TYPE_AMO_AND_P2_REQ ) ||
-                              (msg_type_S2_f == `MSG_TYPE_AMO_OR_P2_REQ  ) ||
-                              (msg_type_S2_f == `MSG_TYPE_AMO_XOR_P2_REQ ) ||
-                              (msg_type_S2_f == `MSG_TYPE_AMO_MAX_P2_REQ ) ||
-                              (msg_type_S2_f == `MSG_TYPE_AMO_MAXU_P2_REQ) ||
-                              (msg_type_S2_f == `MSG_TYPE_AMO_MIN_P2_REQ ) ||
-                              (msg_type_S2_f == `MSG_TYPE_AMO_MINU_P2_REQ) ||
-                              (msg_type_S2_f == `MSG_TYPE_NC_STORE_REQ) ||
-                              (msg_type_S2_f == `MSG_TYPE_CAS_P1_REQ) ||
-                              (msg_type_S2_f == `MSG_TYPE_CAS_P2N_REQ) || (msg_type_S2_f == `MSG_TYPE_INTERRUPT_FWD);
+wire msg_carrying_data_S1 = (msg_data_16B_amo_S1 && ((msg_type_trans_S1 == `MSG_TYPE_SWAP_P1_REQ) || (msg_type_trans_S1 == `MSG_TYPE_SWAPWB_P1_REQ))) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_CAS_P2Y_REQ    ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_SWAP_P2_REQ    ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_SWAPWB_P2_REQ  ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_AMO_ADD_P2_REQ ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_AMO_AND_P2_REQ ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_AMO_OR_P2_REQ  ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_AMO_XOR_P2_REQ ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_AMO_MAX_P2_REQ ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_AMO_MAXU_P2_REQ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_AMO_MIN_P2_REQ ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_AMO_MINU_P2_REQ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_NC_STORE_REQ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_CAS_P1_REQ) ||
+                              (msg_type_trans_S1 == `MSG_TYPE_CAS_P2N_REQ) || (msg_type_trans_S1 == `MSG_TYPE_INTERRUPT_FWD);
 always @(*) begin
     // This is a pretty conservative stall, but we actually won't have many cases with msg_data_pending.
     // For requests that carries msg_data (nc_store, atomic), they might get into mshr. In this case,

--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -941,10 +941,8 @@ begin
     stall_msg_S1 = msg_data_rd_S1 && ~msg_data_valid_S1;
 end
 
-wire msg_carrying_data_S1 = (msg_data_16B_amo_S1 && ((msg_type_trans_S1 == `MSG_TYPE_SWAP_P1_REQ) || (msg_type_trans_S1 == `MSG_TYPE_SWAPWB_P1_REQ))) ||
-                              (msg_type_trans_S1 == `MSG_TYPE_CAS_P2Y_REQ    ) ||
+wire msg_carrying_data_S1 =   (msg_type_trans_S1 == `MSG_TYPE_CAS_P2Y_REQ    ) ||
                               (msg_type_trans_S1 == `MSG_TYPE_SWAP_P2_REQ    ) ||
-                              (msg_type_trans_S1 == `MSG_TYPE_SWAPWB_P2_REQ  ) ||
                               (msg_type_trans_S1 == `MSG_TYPE_AMO_ADD_P2_REQ ) ||
                               (msg_type_trans_S1 == `MSG_TYPE_AMO_AND_P2_REQ ) ||
                               (msg_type_trans_S1 == `MSG_TYPE_AMO_OR_P2_REQ  ) ||
@@ -957,11 +955,13 @@ wire msg_carrying_data_S1 = (msg_data_16B_amo_S1 && ((msg_type_trans_S1 == `MSG_
                               (msg_type_trans_S1 == `MSG_TYPE_CAS_P1_REQ) ||
                               (msg_type_trans_S1 == `MSG_TYPE_CAS_P2N_REQ) || (msg_type_trans_S1 == `MSG_TYPE_INTERRUPT_FWD);
 always @(*) begin
-    // This is a pretty conservative stall, but we actually won't have many cases with msg_data_pending.
-    // For requests that carries msg_data (nc_store, atomic), they might get into mshr. In this case,
-    // msg_data_val would be high for a long time, until that request come back from mshr and raise 
-    // msg_data_ready. During this period, if another request carrying data arrives, it will read the 
-    // wrong data. To prevent this, we simply stop accepting new request until msg_data_pending is resolved.
+    // We only need to worry about the case where a nc_store gets into mshr. 
+    // In this case, msg_data is not consumed immediately and msg_data_val 
+    // would be high for a long time, until that request come back from mshr 
+    // and raise msg_data_ready. During this period, if another request carrying 
+    // data (e.g. another nc_store, atomics, or interrupt_fwd) arrives, it will 
+    // read the wrong data. To prevent this, we simply stop accepting new request 
+    // until msg_data_pending is resolved.
     stall_msg_data_S1 = (msg_data_pending || msg_data_pending_f) && msg_carrying_data_S1 && !msg_from_mshr_S1;
 end
 
@@ -2211,6 +2211,12 @@ always @ *
 begin
     msg_data_ready_S2 = valid_S2 && !stall_S2 && (cs_S2[`CS_STATE_DATA_RDY_P1S2] || msg_data_rd_S2_f);
 end
+
+// Actually it's conservative to use msg_carrying_data_S2_f as
+// the condition to raise the msg_data_pending flag. For atomic operations,
+// it's already guaranteed that no other noc reqs can be consumes by L2 
+// until it reaches phase 2. But being conservative makes no harm to
+// the performance, it's just a double check.
 
 always @(*) begin
     msg_data_pending = 1'b0;


### PR DESCRIPTION
### Problem description: 

Some noc1 requests getting into L2 pipe1 contain msg_data (e.g. nc_store, atomics, interrupt forward), but the pipeline does not always consume the data immediately. While the request being pushed into mshr, the msg_data is not stored in mshr array, but being left in the noc1 buffer. At this moment, if another request gets into L2 pipe1, and also trying to consume msg_data, it would read out the msg_data of the previous request. 

###  Is this problem real and triggerable?

Only two types of request may contain msg_data and has the potential to be pushed in mshr, **atomic operation** and **nc store**, which may cause the msg_data pending at the buffer. 

#### atomic operation
An atomic operation is divided into two internal requests in L2: xx_P1 and xx_P2. In phase1 it will invalidate all sharers if the line is in S/M state; in phase2 it will read msg_data and do the arithmetic computation.  L2 stalls the first stage between phase1 and phase2, and won't ack the msg header until it reaches phase2. Thus, no new requests can be processed by the pipe when a msg_data in the atomic operation is pending. A request in mshr can be recovered between phase1 and phase2, though, and that request may even be a nc_store. But in this case it was the nc_store what arrived at L2 first and made the msg_data pending, we'll discuss that in the next case.

So the conclusion is: due to the late ask of the msg header, we've already prevented new operations being consumed during the time when a msg_data in atomic operation is pending. @morenes also wrote tests to issue lots of consecutive atomic operations from multiple threads to try to trigger this problem, but we saw nothing happened. It's kind of verified that we are fine in this case.

#### non-cacheable store  
If the target line of the nc_store is already in S/M state, L2 will firstly invalidate all the sharers and push the nc_store into mshr. At this time the msg_data is pending, and bad thing may happen if the pipe receives another request which carries msg_data as well. However, with Ariane core this case could not be triggered, because the non-cacheable region is fixed, and the line in the nc space will never be stored in L2.  

The plan would be either try to build a test with sparc core, sending nc_store to a previous cacheable address, or using other device sending nc_store to cacheable region. 

### This fix

The idea of this fix is to figure out when the msg_data is pending. It would raise a flag `msg_data_pending` when a request is supposed to consume msg_data, but not and in reality being pushed into mshr. When that flag is set, the pipeline would not accept new request which also carries msg_data. 

It's verified that this fix would not break the system. But we need further tests to make sure this problem would actually be triggered and this fix could solve the problem. 

