### PR TITLE
Extend total_num_tiles to 32 bits, and set the default value in chip.v

### DIFF
--- a/piton/design/chip/rtl/chip.v.pyv
+++ b/piton/design/chip/rtl/chip.v.pyv
@@ -1033,6 +1033,8 @@ module chip(
        print(xbartemplate.replace("noc1", "noc3"))
 %>
 
+    wire [31:0] default_total_num_tiles;
+    assign default_total_num_tiles = `PITON_NUM_TILES;
     // Generate tile instances
 <%
     template = r'''
@@ -1044,6 +1046,7 @@ module chip(
         .default_chipid             (14'b0),    // the first chip
         .default_coreid_x           (COREIDX),
         .default_coreid_y           (COREIDY),
+        .default_total_num_tiles    (default_total_num_tiles      ),
         .flat_tileid                (`JTAG_FLATID_WIDTH'd_FLAT_ID_)
     `ifdef PITON_RV64_PLATFORM
     `ifdef PITON_RV64_DEBUGUNIT

--- a/piton/design/chip/tile/l15/rtl/l15.v
+++ b/piton/design/chip/tile/l15/rtl/l15.v
@@ -194,7 +194,7 @@ l15_csm l15_csm(
     // config regs
     .l15_hmt_base_reg(config_hmt_base),
     .csm_en(config_csm_en),
-    .system_tile_count(config_system_tile_count[`HOME_ID_WIDTH-1:0]),
+    .system_tile_count(config_system_tile_count),
     .home_alloc_method(config_home_alloc_method),
     
     // interface with pipeline

--- a/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
+++ b/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
@@ -55,7 +55,7 @@ module l15_csm(
    input wire csm_en,
 
    // static system input / configure registers
-   input wire [`HOME_ID_WIDTH-1:0] system_tile_count,
+   input wire [31:0] system_tile_count,
    input wire [`HOME_ALLOC_METHOD_WIDTH-1:0] home_alloc_method, 
    input wire [`L15_HMT_BASE_ADDR_WIDTH-1:0] l15_hmt_base_reg,
 

--- a/piton/design/chip/tile/l15/rtl/l15_wrap.v
+++ b/piton/design/chip/tile/l15/rtl/l15_wrap.v
@@ -89,7 +89,7 @@ module l15_wrap (
     // input from config registers to pipeline
     input [63:0]                            config_l15_read_res_data_s3,
     input                                   config_csm_en,
-    input [5:0]                             config_system_tile_count_5_0,
+    input [31:0]                            config_system_tile_count,
     input [`HOME_ALLOC_METHOD_WIDTH-1:0]    config_home_alloc_method, 
     input [`L15_HMT_BASE_ADDR_WIDTH-1:0]    config_hmt_base,
 
@@ -117,8 +117,6 @@ module l15_wrap (
     input  [`SRAM_WRAPPER_BUS_WIDTH-1:0]    rtap_srams_bist_data
 );
 
-    wire [31:0]   config_system_tile_count = {26'bx, config_system_tile_count_5_0};
-   
     l15 l15 (
         .clk(clk),
         .rst_n(rst_n),

--- a/piton/design/chip/tile/rtl/config_regs.v.pyv
+++ b/piton/design/chip/tile/rtl/config_regs.v.pyv
@@ -60,6 +60,7 @@ module config_regs(
    input wire [`NOC_CHIPID_WIDTH-1:0] default_chipid,
    input wire [`NOC_X_WIDTH-1:0] default_coreid_x,
    input wire [`NOC_Y_WIDTH-1:0] default_coreid_y,
+   input wire [31:0] default_total_num_tiles,
 
 <%
 for i in range(DMBR_BIN_NUM):
@@ -155,8 +156,6 @@ assign config_chipid = chipid;
 assign config_coreid_x = coreid_x;
 assign config_coreid_y = coreid_y;
 
-localparam default_total_num_tile = `PITON_NUM_TILES;
-
 always @ (posedge clk)
 begin
    if (!rst_n)
@@ -176,7 +175,7 @@ begin
       dmbr_rd_cur_val <= 1'b0;
       hmt_base <= `L15_HMT_BASE_ADDR_WIDTH'b0;
       csm_en <= 1'b0;
-      system_tile_count <= default_total_num_tile;
+      system_tile_count <= default_total_num_tiles;
       home_alloc_method <= `HOME_ALLOC_MIXED_ORDER_BITS;
       chipid <= default_chipid;
       coreid_x <= default_coreid_x;

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -45,6 +45,7 @@ module tile #(
     input wire [`NOC_CHIPID_WIDTH-1:0]  default_chipid,
     input wire [`NOC_X_WIDTH-1:0]       default_coreid_x,
     input wire [`NOC_Y_WIDTH-1:0]       default_coreid_y,
+    input wire [31:0]                   default_total_num_tiles,
     input wire [`JTAG_FLATID_WIDTH-1:0] flat_tileid,
 
     // UCB interface for test access port
@@ -1155,7 +1156,7 @@ print(str)
         // config regs
         .config_csm_en(config_csm_en),
         .config_hmt_base(config_hmt_base),
-        .config_system_tile_count_5_0(config_system_tile_count[5:0]),
+        .config_system_tile_count(config_system_tile_count),
         .config_home_alloc_method(config_home_alloc_method),
 
         // sram interfaces
@@ -1252,6 +1253,7 @@ print(str)
         .default_chipid               (default_chipid               ),
         .default_coreid_x             (default_coreid_x             ),
         .default_coreid_y             (default_coreid_y             ),
+        .default_total_num_tiles      (default_total_num_tiles      ),
 
         .config_hmt_base              (config_hmt_base              ),
 


### PR DESCRIPTION
1.  Set default_total_num_tiles in chip level. This may help with the physical design, or the reuse of the config module among different chip configurations. 
2.  Extend total_num_tiles to 32 bits all the way down to l15_csm, to support a much larger configuration