### PR TITLE
fix the issue that load_noshare returns stale data

### DIFF
--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -1707,25 +1707,17 @@ begin
                     `endif
                     `L2_MESI_E:
                     begin
-                        if (req_from_owner_S2 && (cache_type_S2_f == l2_way_state_cache_type_S2))
+                        `ifndef NO_RTL_CSM
+                        if (csm_en)
                         begin
-                            cs_S2 = {`L2_AMO_ALU_NOP, n,         rd,      `OP_CLR, y,      rd,            n,       n,         `OP_CLR,    n,      n,
-                                     `OP_CLR,   n,       n,      `L2_VD_INVAL,  n,      `L2_MESI_I, y,      `L2_LRU_SET};
+                            cs_S2 = {`L2_AMO_ALU_NOP, y,         rd,      `OP_CLR, n,      rd,            y,       n,         `OP_CLR,    n,      n,
+                                     `OP_CLR,   n,       n,      `L2_VD_INVAL,  n,      `L2_MESI_I, n,      `L2_LRU_CLR};
                         end
                         else
+                        `endif
                         begin
-                            `ifndef NO_RTL_CSM
-                            if (csm_en)
-                            begin
-                                cs_S2 = {`L2_AMO_ALU_NOP, y,         rd,      `OP_CLR, n,      rd,            y,       n,         `OP_CLR,    n,      n,
-                                         `OP_CLR,   n,       n,      `L2_VD_INVAL,  n,      `L2_MESI_I, n,      `L2_LRU_CLR};
-                            end
-                            else
-                            `endif
-                            begin
-                                cs_S2 = {`L2_AMO_ALU_NOP, n,         rd,      `OP_CLR, n,      rd,            y,       n,         `OP_CLR,    n,      n,
-                                         `OP_CLR,   n,       n,      `L2_VD_INVAL,  n,      `L2_MESI_I, n,      `L2_LRU_CLR};
-                            end
+                            cs_S2 = {`L2_AMO_ALU_NOP, n,         rd,      `OP_CLR, n,      rd,            y,       n,         `OP_CLR,    n,      n,
+                                     `OP_CLR,   n,       n,      `L2_VD_INVAL,  n,      `L2_MESI_I, n,      `L2_LRU_CLR};
                         end
                     end
                     default:
@@ -3230,7 +3222,7 @@ begin
                     end
                     `L2_MESI_E:
                     begin
-                        if (req_from_owner_S4 && (cache_type_S4_f == l2_way_state_cache_type_S4))
+                        if (msg_type_S4_f == `MSG_TYPE_LOAD_REQ && req_from_owner_S4 && (cache_type_S4_f == l2_way_state_cache_type_S4))
                         begin
                             cs_S4 = {n,         y,          `MSG_TYPE_DATA_ACK,    n,          `MSG_TYPE_ERROR};
                         end


### PR DESCRIPTION
Ci-Chian(@cichian) found this issue that load_noshare returns the old data in LLC when the line has a modified state in private L1.5 cache. The testbench to trigger this is: single tile configuration, besides L1.5, we have another device that can send load_noshare. store X in address A, then send load_noshare on address A. Load_noshare returns all zeros but not X.

This issue happens when we have a tile that uses both L1.5 and another engine which can send load_noshare. When L2 handles load_noshare, it still checks whether the request comes from the owner of this line. If it is from the owner, it will not downgrade the owner's private cacheline to S state. But this is not correct. The device which sends out load_noshare is independent from L1.5. Even though they are from the same tile, the load_noshare request arrives L2 first, and it needs to downgrade the line in L1.5 from the same tile.   

This fix removed the logic in L2 which checks whether the load_noshare request is from the owner of this line, and we always send out downgrade request.
