### PR TITLE
fix: prevent latch inference

### DIFF
--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -3624,6 +3624,7 @@ end
 
 always @ *
 begin
+	msg_send_data_size_S4 = `MSG_DATA_SIZE_0B;
     if (msg_send_valid_S4)
     begin
         case (msg_send_type_S4)


### PR DESCRIPTION
This PR prevents latch inference by assigning a default value to `msg_send_data_size_S4`