### PR TITLE
Integration of AIA into openpiton

### DIFF
--- a/piton/design/chip/rtl/chip.v.pyv
+++ b/piton/design/chip/rtl/chip.v.pyv
@@ -159,29 +159,7 @@ module chip(
 `elsif  PITON_RV64_APLIC
 // APLIC
 `ifdef DIRECT_MODE
-,   output [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]   irq_i   
-`else
-,   output wire [31:0]                          msi_noc1_axi_awaddr
-,   output wire                                 msi_noc1_axi_awvalid
-,   input  wire                                 noc1_msi_axi_awready
-  
-,   output wire [31:0]                          msi_noc1_axi_wdata
-,   output wire [3:0]                           msi_noc1_axi_wstrb
-,   output wire                                 msi_noc1_axi_wvalid
-,   input  wire                                 noc1_msi_axi_wready
-  
-,   input  wire [1:0]                           noc1_msi_axi_bresp
-,   input  wire                                 noc1_msi_axi_bvalid
-,   output wire                                 msi_noc1_axi_bready
-  
-,   output wire [31:0]                          msi_noc1_axi_araddr
-,   output wire                                 msi_noc1_axi_arvalid
-,   input  wire                                 noc1_msi_axi_arready
-  
-,   input  wire [31:0]                          noc1_msi_axi_rdata
-,   input  wire [1:0]                           noc1_msi_axi_rresp
-,   input  wire                                 noc1_msi_axi_rvalid
-,   output wire                                 msi_noc1_axi_rready
+,   input [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]   irq_i                                    
 `endif // DIRECT_MODE
 
 `endif // ifdef PITON_RV64_PLIC

--- a/piton/design/chip/rtl/chip.v.pyv
+++ b/piton/design/chip/rtl/chip.v.pyv
@@ -156,6 +156,34 @@ module chip(
 `ifdef PITON_RV64_PLIC
     // PLIC
 ,   input   [`PITON_NUM_TILES*2-1:0]            irq_i           // level sensitive IR lines, mip & sip (async)
+`elsif  PITON_RV64_APLIC
+// APLIC
+`ifdef DIRECT_MODE
+,   output [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]   irq_i   
+`else
+,   output wire [31:0]                          msi_noc1_axi_awaddr
+,   output wire                                 msi_noc1_axi_awvalid
+,   input  wire                                 noc1_msi_axi_awready
+  
+,   output wire [31:0]                          msi_noc1_axi_wdata
+,   output wire [3:0]                           msi_noc1_axi_wstrb
+,   output wire                                 msi_noc1_axi_wvalid
+,   input  wire                                 noc1_msi_axi_wready
+  
+,   input  wire [1:0]                           noc1_msi_axi_bresp
+,   input  wire                                 noc1_msi_axi_bvalid
+,   output wire                                 msi_noc1_axi_bready
+  
+,   output wire [31:0]                          msi_noc1_axi_araddr
+,   output wire                                 msi_noc1_axi_arvalid
+,   input  wire                                 noc1_msi_axi_arready
+  
+,   input  wire [31:0]                          noc1_msi_axi_rdata
+,   input  wire [1:0]                           noc1_msi_axi_rresp
+,   input  wire                                 noc1_msi_axi_rvalid
+,   output wire                                 msi_noc1_axi_rready
+`endif // DIRECT_MODE
+
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
 );

--- a/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
+++ b/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
@@ -402,6 +402,10 @@ end
 reg  on_chip_dev_access_s3;
 reg [`NOC_X_WIDTH-1:0] on_chip_dev_access_x_s3;
 reg [`NOC_Y_WIDTH-1:0] on_chip_dev_access_y_s3;
+reg aia_imsic_access_s3;
+reg [`HOME_ID_WIDTH-1:0] aia_imsic_access_flatid_s3;
+wire [`NOC_X_WIDTH-1:0] aia_imsic_access_x_s3;
+wire [`NOC_Y_WIDTH-1:0] aia_imsic_access_y_s3;
 always @ *
 begin
     //on-chip device accesses start with 0xE0 or 0xE1
@@ -409,7 +413,18 @@ begin
 
     on_chip_dev_access_x_s3 = l15_csm_req_address_s3[`ON_CHIP_DEV_X_POS];
     on_chip_dev_access_y_s3 = l15_csm_req_address_s3[`ON_CHIP_DEV_Y_POS];
+
+    // AIA IMSIC device accesses start with 0xE3
+    aia_imsic_access_s3 = (l15_csm_req_address_s3[39:32] == 8'he3);
+
+    aia_imsic_access_flatid_s3 = l15_csm_req_address_s3[`AIA_IMSIC_FLATID_POS];
 end
+
+flat_id_to_xy lhid_to_xy (
+    .flat_id(aia_imsic_access_flatid_s3[`HOME_ID_WIDTH-1:0]),
+    .x_coord(aia_imsic_access_x_s3),
+    .y_coord(aia_imsic_access_y_s3)
+    );
 
 `ifndef NO_RTL_CSM
 
@@ -508,8 +523,21 @@ begin
         begin
             csm_l15_res_data_s3 = 0;
             csm_l15_res_data_s3[`PACKET_HOME_ID_CHIP_MASK] = 1'b0; // non-csm mode only has 1 chip alone
-            csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = on_chip_dev_access_s3 ? on_chip_dev_access_y_s3 : lhid_s3_y;
-            csm_l15_res_data_s3[`PACKET_HOME_ID_X_MASK] = on_chip_dev_access_s3 ? on_chip_dev_access_x_s3 : lhid_s3_x;
+            if (on_chip_dev_access_s3)
+            begin
+                csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = on_chip_dev_access_y_s3;
+                csm_l15_res_data_s3[`PACKET_HOME_ID_X_MASK] = on_chip_dev_access_x_s3;
+            end
+            else if (aia_imsic_access_s3)
+            begin
+                csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = aia_imsic_access_y_s3;
+                csm_l15_res_data_s3[`PACKET_HOME_ID_X_MASK] = aia_imsic_access_x_s3;
+            end
+            else
+            begin
+                csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = lhid_s3_y;
+                csm_l15_res_data_s3[`PACKET_HOME_ID_X_MASK] = lhid_s3_x;
+            end
         end
     end
 end
@@ -688,8 +716,21 @@ always @ *
 begin
     csm_l15_res_data_s3 = 0;
     csm_l15_res_data_s3[`PACKET_HOME_ID_CHIP_MASK] = 1'b0; // non-csm mode only has 1 chip alone
-    csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = on_chip_dev_access_s3 ? on_chip_dev_access_y_s3 : lhid_s3_y;
-    csm_l15_res_data_s3[`PACKET_HOME_ID_X_MASK] = on_chip_dev_access_s3 ? on_chip_dev_access_x_s3 : lhid_s3_x;
+    if (on_chip_dev_access_s3)
+    begin
+        csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = on_chip_dev_access_y_s3;
+        csm_l15_res_data_s3[`PACKET_HOME_ID_X_MASK] = on_chip_dev_access_x_s3;
+    end
+    else if (aia_imsic_access_s3)
+    begin
+        csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = aia_imsic_access_y_s3;
+        csm_l15_res_data_s3[`PACKET_HOME_ID_X_MASK] = aia_imsic_access_x_s3;
+    end
+    else
+    begin
+        csm_l15_res_data_s3[`PACKET_HOME_ID_Y_MASK] = lhid_s3_y;
+        csm_l15_res_data_s3[`PACKET_HOME_ID_X_MASK] = lhid_s3_x;
+    end
 end
 
 flat_id_to_xy lhid_to_xy (

--- a/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
+++ b/piton/design/chip/tile/l15/rtl/l15_csm.v.pyv
@@ -420,7 +420,7 @@ begin
     aia_imsic_access_flatid_s3 = l15_csm_req_address_s3[`AIA_IMSIC_FLATID_POS];
 end
 
-flat_id_to_xy lhid_to_xy (
+flat_id_to_xy lhid_to_xy_imsic (
     .flat_id(aia_imsic_access_flatid_s3[`HOME_ID_WIDTH-1:0]),
     .x_coord(aia_imsic_access_x_s3),
     .y_coord(aia_imsic_access_y_s3)

--- a/piton/design/chip/tile/l15/rtl/noc1encoder.v
+++ b/piton/design/chip/tile/l15/rtl/noc1encoder.v
@@ -276,8 +276,18 @@ begin
    // Set fbits for on-chip device access according to the fbits field in addr
    // For interrupt controller access, hard code the fbits. This is DECADES_CHIP specific. 
    // otherwise set fbits to 0 (target L2)
-   msg_dest_fbits = (noc1buffer_noc1encoder_req_address[39:33] == 7'b1110000) ?
-                   noc1buffer_noc1encoder_req_address[`ON_CHIP_DEV_FBITS] : `NOC_FBITS_L2;
+   if (noc1buffer_noc1encoder_req_address[39:33] == 7'b1110000)
+   begin
+       msg_dest_fbits = noc1buffer_noc1encoder_req_address[`ON_CHIP_DEV_FBITS];
+   end
+   else if (noc1buffer_noc1encoder_req_address[39:32] == 8'he3)
+   begin
+       msg_dest_fbits = `NOC_FBITS_AIA;
+   end
+   else
+   begin
+       msg_dest_fbits = `NOC_FBITS_L2;
+   end
 
    // default value for a message, will be overwritten by interrupt reqs
    msg_dest_l2_xpos = req_dest_l2_xpos;

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -200,6 +200,12 @@ print(s)
 `ifdef PITON_RV64_PLIC
     // PLIC
 ,   input   [1:0]                       irq_i          // level sensitive IR lines, mip & sip (async)
+`elsif  PITON_RV64_APLIC
+// APLIC
+`ifdef DIRECT_MODE
+,   input [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]   irq_i   
+`endif // DIRECT_MODE
+
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
 );
@@ -1119,7 +1125,11 @@ print(str)
         .spc_grst_l  ( spc_grst_l             ),
         .boot_addr_i ( ariane_bootaddr        ),
         .hart_id_i   ( {{64-`JTAG_FLATID_WIDTH{1'b0}}, flat_tileid} ),
+        `ifndef MSI_MODE
         .irq_i       ( irq_i                  ),
+        `else
+        .irq_i       ( xeip_targets           ),
+        `endif
         .ipi_i       ( ipi_i                  ),
         .time_irq_i  ( timer_irq_i            ),
         .debug_req_i ( debug_req_i            ),
@@ -1251,40 +1261,44 @@ print(str)
 //
       ariane_axi::req_t  msi_req;
       ariane_axi::resp_t msi_resp;
+
+//    `ifdef MSI_MODE
+//    assign msi_req.aw_valid     = msi_noc1_axi_awvalid;
+//    assign msi_req.aw.addr      = msi_noc1_axi_awaddr;
+//    assign noc2_msi_axi_awready = msi_resp.aw_ready;
 //
-//    assign msi_req.aw_valid    = imsic_s_axi_awvalid;
-//    assign msi_req.aw.addr     = imsic_s_axi_awaddr;
-//    assign imsic_s_axi_awready = msi_resp.aw_ready;
+//    assign msi_req.w_valid     = msi_noc1_axi_wvalid;
+//    assign msi_req.w.data      = msi_noc1_axi_wdata;
+//    assign msi_req.w.strb      = msi_noc1_axi_wstrb;
+//    assign noc2_msi_axi_wready = msi_resp.w_ready;
 //
-//    assign msi_req.w_valid    = imsic_s_axi_wvalid;
-//    assign msi_req.w.data     = imsic_s_axi_wdata;
-//    assign msi_req.w.strb     = imsic_s_axi_wstrb;
-//    assign imsic_s_axi_wready = msi_resp.w_ready;
+//    assign msi_req.ar_valid     = msi_noc1_axi_arvalid;
+//    assign msi_req.ar.addr      = msi_noc1_axi_araddr;
+//    assign noc2_msi_axi_arready = msi_resp.ar_ready;    
 //
-//    assign msi_req.ar_valid    = imsic_s_axi_arvalid;
-//    assign msi_req.ar.addr     = imsic_s_axi_araddr;
-//    assign imsic_s_axi_arready = msi_resp.ar_ready;    
+//    assign msi_req.r_ready     = msi_noc1_axi_rready;
+//    assign noc2_msi_axi_rvalid = msi_resp.r_valid;     
+//    assign noc2_msi_axi_rdata  = msi_resp.r.data;     
+//    assign noc2_msi_axi_rresp  = msi_resp.r.resp;   
 //
-//    assign msi_req.r_ready    = imsic_s_axi_rready;
-//    assign imsic_s_axi_rvalid = msi_resp.r_valid;     
-//    assign imsic_s_axi_rdata  = msi_resp.r.data;     
-//    assign imsic_s_axi_rresp  = msi_resp.r.resp;   
-//
-//    assign msi_req.b_ready    = imsic_s_axi_bready;
+//    assign msi_req.b_ready    = msi_noc1_axi_bready;
 //    assign imsic_s_axi_bvalid = msi_resp.b_valid;
 //    assign imsic_s_axi_bresp  = msi_resp.b.resp;
+//    `endif
+//
+//    `ifdef MSI_MODE
+//    assign src_chipid   = processor_merger_vr_noc1_dat[`MSG_SRC_CHIPID_];
+//    assign src_coreid_x = processor_merger_vr_noc1_dat[`MSG_SRC_X_];
+//    assign src_coreid_y = processor_merger_vr_noc1_dat[`MSG_SRC_Y_];
+//    assign src_fbits    = processor_merger_vr_noc1_dat[`MSG_SRC_FBITS_];
+//
+//    assign dst_chipid   = processor_merger_vr_noc1_dat[`MSG_DST_CHIPID];
+//    assign dst_coreid_x = processor_merger_vr_noc1_dat[`MSG_DST_X];
+//    assign dst_coreid_y = processor_merger_vr_noc1_dat[`MSG_DST_Y];
+//    assign dst_fbits    = processor_merger_vr_noc1_dat[`MSG_DST_FBITS];
+//    `endif // MSI_MODE
 
-    `ifdef MSI_MODE
-    assign src_chipid   = processor_merger_vr_noc1_dat[`MSG_SRC_CHIPID_];
-    assign src_coreid_x = processor_merger_vr_noc1_dat[`MSG_SRC_X_];
-    assign src_coreid_y = processor_merger_vr_noc1_dat[`MSG_SRC_Y_];
-    assign src_fbits    = processor_merger_vr_noc1_dat[`MSG_SRC_FBITS_];
-
-    assign dst_chipid   = processor_merger_vr_noc1_dat[`MSG_DST_CHIPID];
-    assign dst_coreid_x = processor_merger_vr_noc1_dat[`MSG_DST_X];
-    assign dst_coreid_y = processor_merger_vr_noc1_dat[`MSG_DST_Y];
-    assign dst_fbits    = processor_merger_vr_noc1_dat[`MSG_DST_FBITS];
-    `endif // MSI_MODE
+    logic [1:0] xeip_targets;
 
     // INSTANTIATE IMSIC HERE and stop driving wires above
     imsic_top # (
@@ -1310,7 +1324,7 @@ print(str)
         .i_imsic_claim     (       ),
         .o_imsic_data      (       ),
         .o_xtopei          (       ),
-        .o_Xeip_targets    (       ),
+        .o_Xeip_targets    ( xeip_targets      ),
         .o_imsic_exception (       )
     );
 

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -53,6 +53,18 @@ module tile #(
     input [`UCB_BUS_WIDTH-1:0]          jtag_tiles_ucb_data,
     output                              tile_jtag_ucb_val,
     output [`UCB_BUS_WIDTH-1:0]         tile_jtag_ucb_data,
+    
+    `ifdef MSI_MODE
+    output wire [`NOC_CHIPID_WIDTH-1:0] src_chipid,
+    output wire [`NOC_X_WIDTH-1:0]      src_coreid_x,
+    output wire [`NOC_Y_WIDTH-1:0]      src_coreid_y, 
+    output wire [`NOC_FBITS_WIDTH-1:0]  src_fbits,
+
+    output wire [`NOC_CHIPID_WIDTH-1:0] dst_chipid,
+    output wire [`NOC_X_WIDTH-1:0]      dst_coreid_x,
+    output wire [`NOC_Y_WIDTH-1:0]      dst_coreid_y, 
+    output wire [`NOC_FBITS_WIDTH-1:0]  dst_fbits,
+    `endif //MSI_MODE
 <%
 s = '''
     // Dynamic Network Inputs 0 (User Dynamic Network)
@@ -1262,6 +1274,18 @@ print(str)
 //    assign imsic_s_axi_bvalid = msi_resp.b_valid;
 //    assign imsic_s_axi_bresp  = msi_resp.b.resp;
 
+    `ifdef MSI_MODE
+    assign src_chipid   = processor_merger_vr_noc1_dat[`MSG_SRC_CHIPID_];
+    assign src_coreid_x = processor_merger_vr_noc1_dat[`MSG_SRC_X_];
+    assign src_coreid_y = processor_merger_vr_noc1_dat[`MSG_SRC_Y_];
+    assign src_fbits    = processor_merger_vr_noc1_dat[`MSG_SRC_FBITS_];
+
+    assign dst_chipid   = processor_merger_vr_noc1_dat[`MSG_DST_CHIPID];
+    assign dst_coreid_x = processor_merger_vr_noc1_dat[`MSG_DST_X];
+    assign dst_coreid_y = processor_merger_vr_noc1_dat[`MSG_DST_Y];
+    assign dst_fbits    = processor_merger_vr_noc1_dat[`MSG_DST_FBITS];
+    `endif // MSI_MODE
+
     // INSTANTIATE IMSIC HERE and stop driving wires above
     imsic_top # (
         .NR_SRC            ( 32                 ),
@@ -1270,7 +1294,7 @@ print(str)
         .AXI_ADDR_WIDTH    ( 32                 ),
         .AXI_DATA_WIDTH    ( 32                 ),
         .axi_req_t         ( ariane_axi::req_t  ),
-        .axi_resp_t        ( ariane_axi::resp_t ),   
+        .axi_resp_t        ( ariane_axi::resp_t )
     ) imsic (
         .i_clk             ( clk   ),
         .ni_rst            ( rst_n ),

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -211,42 +211,87 @@ print(s)
     wire [`NOC_X_WIDTH-1:0]             config_coreid_x;
     wire [`NOC_Y_WIDTH-1:0]             config_coreid_y;
 
-    wire [`DATA_WIDTH-1:0]              buffer_processor_data_noc1;
-    wire [`DATA_WIDTH-1:0]              buffer_processor_data_noc2;
-    wire [`DATA_WIDTH-1:0]              buffer_processor_data_noc3;
+    wire [`DATA_WIDTH-1:0]              buffer_splitter_vr_noc1_dat;
+    wire [`DATA_WIDTH-1:0]              buffer_splitter_vr_noc2_dat;
+    wire [`DATA_WIDTH-1:0]              buffer_splitter_vr_noc3_dat;
 
-    wire                                buffer_processor_valid_noc1;
-    wire                                buffer_processor_valid_noc2;
-    wire                                buffer_processor_valid_noc3;
-    wire                                processor_router_ready_noc1;
-    wire                                processor_router_ready_noc2;
-    wire                                processor_router_ready_noc3;
+    wire [`NOC_DATA_WIDTH-1:0]          merger_buffer_vr_noc1_dat;
+    wire [`NOC_DATA_WIDTH-1:0]          merger_buffer_vr_noc2_dat;
+    wire [`NOC_DATA_WIDTH-1:0]          merger_buffer_vr_noc3_dat;
 
-    wire                                router_processor_ready_noc1;
-    wire                                router_processor_ready_noc2;
-    wire                                router_processor_ready_noc3;
+    wire                                buffer_splitter_vr_noc1_val;
+    wire                                buffer_splitter_vr_noc2_val;
+    wire                                buffer_splitter_vr_noc3_val;
+    wire                                buffer_splitter_vr_noc1_rdy;
+    wire                                buffer_splitter_vr_noc2_rdy;
+    wire                                buffer_splitter_vr_noc3_rdy;
+
+    wire                                merger_buffer_vr_noc1_val;
+    wire                                merger_buffer_vr_noc2_val;
+    wire                                merger_buffer_vr_noc3_val;
+    wire                                merger_buffer_vr_noc1_rdy;
+    wire                                merger_buffer_vr_noc2_rdy;
+    wire                                merger_buffer_vr_noc3_rdy;
+
+
+    // NoC interface for different intra-tile devices
+    // NoC1
+    wire                                splitter_processor_vr_noc1_val;
+    wire [`NOC_DATA_WIDTH-1:0]          splitter_processor_vr_noc1_dat;
+    wire                                splitter_processor_vr_noc1_rdy;
+    wire                                splitter_dst1_vr_noc1_val;
+    wire [`NOC_DATA_WIDTH-1:0]          splitter_dst1_vr_noc1_dat;
+    wire                                splitter_dst1_vr_noc1_rdy;
+
+    wire                                processor_merger_vr_noc1_val;
+    wire [`NOC_DATA_WIDTH-1:0]          processor_merger_vr_noc1_dat;
+    wire                                processor_merger_vr_noc1_rdy;
+    wire                                src1_merger_vr_noc1_val;
+    wire [`NOC_DATA_WIDTH-1:0]          src1_merger_vr_noc1_dat;
+    wire                                src1_merger_vr_noc1_rdy;
+
+    // NoC2
+    wire                                splitter_processor_vr_noc2_val;
+    wire [`NOC_DATA_WIDTH-1:0]          splitter_processor_vr_noc2_dat;
+    wire                                splitter_processor_vr_noc2_rdy;
+    wire                                splitter_dst1_vr_noc2_val;
+    wire [`NOC_DATA_WIDTH-1:0]          splitter_dst1_vr_noc2_dat;
+    wire                                splitter_dst1_vr_noc2_rdy;
+
+    wire                                processor_merger_vr_noc2_val;
+    wire [`NOC_DATA_WIDTH-1:0]          processor_merger_vr_noc2_dat;
+    wire                                processor_merger_vr_noc2_rdy;
+    wire                                src1_merger_vr_noc2_val;
+    wire [`NOC_DATA_WIDTH-1:0]          src1_merger_vr_noc2_dat;
+    wire                                src1_merger_vr_noc2_rdy;
+    
+    // NoC3
+    wire                                splitter_processor_vr_noc3_val;
+    wire [`NOC_DATA_WIDTH-1:0]          splitter_processor_vr_noc3_dat;
+    wire                                splitter_processor_vr_noc3_rdy;
+    wire                                splitter_dst1_vr_noc3_val;
+    wire [`NOC_DATA_WIDTH-1:0]          splitter_dst1_vr_noc3_dat;
+    wire                                splitter_dst1_vr_noc3_rdy;
+
+    wire                                processor_merger_vr_noc3_val;
+    wire [`NOC_DATA_WIDTH-1:0]          processor_merger_vr_noc3_dat;
+    wire                                processor_merger_vr_noc3_rdy;
+    wire                                src1_merger_vr_noc3_val;
+    wire [`NOC_DATA_WIDTH-1:0]          src1_merger_vr_noc3_dat;
+    wire                                src1_merger_vr_noc3_rdy;
 
     // Processor val/rdy interface
 
-    wire [`NOC_DATA_WIDTH-1:0]          processor_router_data_noc1;
-    wire                                processor_router_valid_noc1;
     wire                                buffer_router_yummy_noc1;
-
     wire [`NOC_DATA_WIDTH-1:0]          buffer_router_data_noc1;
     wire                                buffer_router_valid_noc1;
 
 
-    wire [`NOC_DATA_WIDTH-1:0]          processor_router_data_noc2;
-    wire                                processor_router_valid_noc2;
     wire                                buffer_router_yummy_noc2;
-
     wire [`NOC_DATA_WIDTH-1:0]          buffer_router_data_noc2;
     wire                                buffer_router_valid_noc2;
 
-    wire [`NOC_DATA_WIDTH-1:0]          processor_router_data_noc3;
-    wire                                processor_router_valid_noc3;
     wire                                buffer_router_yummy_noc3;
-
     wire [`NOC_DATA_WIDTH-1:0]          buffer_router_data_noc3;
     wire                                buffer_router_valid_noc3;
 
@@ -604,9 +649,9 @@ NIB_SIZE = pow(2, NIB_SIZE_LOG2)
     valrdy_to_credit #(<%= NIB_SIZE%>, <%= NIB_SIZE_LOG2 + 1%>) cgno_blk1(
         .clk(clk_gated),
         .reset(~rst_n_f),
-        .data_in(processor_router_data_noc1),
-        .valid_in(processor_router_valid_noc1),
-        .ready_in(router_processor_ready_noc1),
+        .data_in(merger_buffer_vr_noc1_dat),
+        .valid_in(merger_buffer_vr_noc1_val),
+        .ready_in(merger_buffer_vr_noc1_rdy),
 
         .data_out(buffer_router_data_noc1),           // Data
         .valid_out(buffer_router_valid_noc1),       // Val signal
@@ -616,9 +661,9 @@ NIB_SIZE = pow(2, NIB_SIZE_LOG2)
     valrdy_to_credit #(<%= NIB_SIZE%>, <%= NIB_SIZE_LOG2 + 1%>) cgno_blk2(
         .clk(clk_gated),
         .reset(~rst_n_f),
-        .data_in(processor_router_data_noc2),
-        .valid_in(processor_router_valid_noc2),
-        .ready_in(router_processor_ready_noc2),
+        .data_in(merger_buffer_vr_noc2_dat),
+        .valid_in(merger_buffer_vr_noc2_val),
+        .ready_in(merger_buffer_vr_noc2_rdy),
 
         .data_out(buffer_router_data_noc2),           // Data
         .valid_out(buffer_router_valid_noc2),       // Val signal
@@ -628,9 +673,9 @@ NIB_SIZE = pow(2, NIB_SIZE_LOG2)
     valrdy_to_credit #(<%= NIB_SIZE%>, <%= NIB_SIZE_LOG2 + 1%>) cgno_blk3(
         .clk(clk_gated),
         .reset(~rst_n_f),
-        .data_in(processor_router_data_noc3),
-        .valid_in(processor_router_valid_noc3),
-        .ready_in(router_processor_ready_noc3),
+        .data_in(processor_merger_vr_noc3_dat),
+        .valid_in(processor_merger_vr_noc3_val),
+        .ready_in(processor_merger_vr_noc3_rdy),
 
         .data_out(buffer_router_data_noc3),           // Data
         .valid_out(buffer_router_valid_noc3),       // Val signal
@@ -645,9 +690,9 @@ NIB_SIZE = pow(2, NIB_SIZE_LOG2)
         .valid_in(router_buffer_data_val_noc1),
         .yummy_in(buffer_router_yummy_noc1),
 
-        .data_out(buffer_processor_data_noc1),           // Data
-        .valid_out(buffer_processor_valid_noc1),       // Val signal from dynamic network to processor
-        .ready_out(processor_router_ready_noc1)    // Rdy signal from processor to dynamic network
+       .data_out(buffer_splitter_vr_noc1_dat),           // Data
+        .valid_out(buffer_splitter_vr_noc1_val),       // Val signal from dynamic network to processor
+        .ready_out(buffer_splitter_vr_noc1_rdy)    // Rdy signal from processor to dynamic network
     );
 
     credit_to_valrdy cgni_blk2(
@@ -657,9 +702,9 @@ NIB_SIZE = pow(2, NIB_SIZE_LOG2)
         .valid_in(router_buffer_data_val_noc2),
         .yummy_in(buffer_router_yummy_noc2),
 
-        .data_out(buffer_processor_data_noc2),           // Data
-        .valid_out(buffer_processor_valid_noc2),       // Val signal from dynamic network to processor
-        .ready_out(processor_router_ready_noc2)    // Rdy signal from processor to dynamic network
+       .data_out(buffer_splitter_vr_noc2_dat),           // Data
+        .valid_out(buffer_splitter_vr_noc2_val),       // Val signal from dynamic network to processor
+        .ready_out(buffer_splitter_vr_noc2_rdy)    // Rdy signal from processor to dynamic network
     );
 
     credit_to_valrdy cgni_blk3(
@@ -669,9 +714,9 @@ NIB_SIZE = pow(2, NIB_SIZE_LOG2)
         .valid_in(router_buffer_data_val_noc3),
         .yummy_in(buffer_router_yummy_noc3),
 
-        .data_out(buffer_processor_data_noc3),           // Data
-        .valid_out(buffer_processor_valid_noc3),       // Val signal from dynamic network to processor
-        .ready_out(processor_router_ready_noc3)    // Rdy signal from processor to dynamic network
+        .data_out(buffer_splitter_vr_noc3_dat),           // Data
+        .valid_out(buffer_splitter_vr_noc3_val),       // Val signal from dynamic network to processor
+        .ready_out(buffer_splitter_vr_noc3_rdy)    // Rdy signal from processor to dynamic network
     );
 
 ///////////////////////
@@ -1038,6 +1083,11 @@ print("    assign ariane_bootaddr  =  64'h%s;" % bootAddr)
 
 
     ariane_verilog_wrap #(
+        // PMA configuration
+        // non-idempotent region: first GB of mem and the range with the bit 40 set (but the range 0xe0-0xef, used for scratchpad)
+        .NrNonIdempotentRules  (3),
+        .NonIdempotentAddrBase ({64'he100000000,64'h8000000000,64'h0000000000}),
+        .NonIdempotentLength   ({64'h1f00000000,64'h6000000000,64'h0040000000}),
 <%
 str = '''
         .NrPMPEntries           ( 4    ),
@@ -1071,6 +1121,166 @@ print(str)
   end
   endgenerate
 
+    noc_simple_splitter noc1_splitter(
+        .clk                        (clk_gated)                     ,
+        .rst_n                      (rst_n_f)                       ,
+
+        .src_splitter_vr_noc_val       (buffer_splitter_vr_noc1_val),
+        .src_splitter_vr_noc_dat       (buffer_splitter_vr_noc1_dat),
+        .src_splitter_vr_noc_rdy       (buffer_splitter_vr_noc1_rdy),
+                                                           
+        .splitter_dst0_vr_noc_val     (splitter_processor_vr_noc1_val), // For L15 and L2
+        .splitter_dst0_vr_noc_dat     (splitter_processor_vr_noc1_dat),
+        .splitter_dst0_vr_noc_rdy     (splitter_processor_vr_noc1_rdy),
+                                                           
+        .splitter_dst1_vr_noc_val     (splitter_dst1_vr_noc1_val),
+        .splitter_dst1_vr_noc_dat     (splitter_dst1_vr_noc1_dat),
+        .splitter_dst1_vr_noc_rdy     (splitter_dst1_vr_noc1_rdy)
+    );
+
+
+    noc_simple_splitter noc2_splitter(
+        .clk                        (clk_gated)                     ,
+        .rst_n                      (rst_n_f)                       ,
+
+        .src_splitter_vr_noc_val       (buffer_splitter_vr_noc2_val),
+        .src_splitter_vr_noc_dat       (buffer_splitter_vr_noc2_dat),
+        .src_splitter_vr_noc_rdy       (buffer_splitter_vr_noc2_rdy),
+                                                           
+        .splitter_dst0_vr_noc_val     (splitter_processor_vr_noc2_val), // For L15 and L2
+        .splitter_dst0_vr_noc_dat     (splitter_processor_vr_noc2_dat),
+        .splitter_dst0_vr_noc_rdy     (splitter_processor_vr_noc2_rdy),
+                                                           
+        .splitter_dst1_vr_noc_val     (splitter_dst1_vr_noc2_val),
+        .splitter_dst1_vr_noc_dat     (splitter_dst1_vr_noc2_dat),
+        .splitter_dst1_vr_noc_rdy     (splitter_dst1_vr_noc2_rdy)
+    );
+
+
+    noc_simple_splitter noc3_splitter(
+        .clk                        (clk_gated)                     ,
+        .rst_n                      (rst_n_f)                       ,
+
+        .src_splitter_vr_noc_val       (buffer_splitter_vr_noc3_val),
+        .src_splitter_vr_noc_dat       (buffer_splitter_vr_noc3_dat),
+        .src_splitter_vr_noc_rdy       (buffer_splitter_vr_noc3_rdy),
+                                                           
+        .splitter_dst0_vr_noc_val     (splitter_processor_vr_noc3_val), // For L15 and L2
+        .splitter_dst0_vr_noc_dat     (splitter_processor_vr_noc3_dat),
+        .splitter_dst0_vr_noc_rdy     (splitter_processor_vr_noc3_rdy),
+                                                           
+        .splitter_dst1_vr_noc_val     (splitter_dst1_vr_noc3_val),
+        .splitter_dst1_vr_noc_dat     (splitter_dst1_vr_noc3_dat),
+        .splitter_dst1_vr_noc_rdy     (splitter_dst1_vr_noc3_rdy)
+    );
+
+
+    noc_simple_merger noc1_merger(   
+        .clk                        (clk_gated),
+        .rst_n                      (rst_n_f),
+                                                          
+        .src0_merger_vr_noc_val       (processor_merger_vr_noc1_val), // For L15 and L2
+        .src0_merger_vr_noc_dat       (processor_merger_vr_noc1_dat),
+        .src0_merger_vr_noc_rdy       (processor_merger_vr_noc1_rdy),
+                                                          
+        .src1_merger_vr_noc_val       (src1_merger_vr_noc1_val),
+        .src1_merger_vr_noc_dat       (src1_merger_vr_noc1_dat),
+        .src1_merger_vr_noc_rdy       (src1_merger_vr_noc1_rdy),
+                                     
+        .merger_dst_vr_noc_val         (merger_buffer_vr_noc1_val),  
+        .merger_dst_vr_noc_dat         (merger_buffer_vr_noc1_dat),
+        .merger_dst_vr_noc_rdy         (merger_buffer_vr_noc1_rdy)   
+    );
+
+
+    noc_simple_merger noc2_merger(   
+        .clk                        (clk_gated),
+        .rst_n                      (rst_n_f),
+                                                          
+        .src0_merger_vr_noc_val       (processor_merger_vr_noc2_val), // For L15 and L2
+        .src0_merger_vr_noc_dat       (processor_merger_vr_noc2_dat),
+        .src0_merger_vr_noc_rdy       (processor_merger_vr_noc2_rdy),
+                                                          
+        .src1_merger_vr_noc_val       (src1_merger_vr_noc2_val),
+        .src1_merger_vr_noc_dat       (src1_merger_vr_noc2_dat),
+        .src1_merger_vr_noc_rdy       (src1_merger_vr_noc2_rdy),
+                                     
+        .merger_dst_vr_noc_val         (merger_buffer_vr_noc2_val),  
+        .merger_dst_vr_noc_dat         (merger_buffer_vr_noc2_dat),
+        .merger_dst_vr_noc_rdy         (merger_buffer_vr_noc2_rdy)   
+    );
+
+    assign splitter_dst1_vr_noc2_rdy = 1'b0;
+    assign splitter_dst1_vr_noc3_rdy = 1'b0;
+    assign src1_merger_vr_noc1_val = 1'b0;  
+    assign src1_merger_vr_noc1_dat = 64'd0;
+
+    wire [11:0] imsic_s_axi_awaddr;
+    wire        imsic_s_axi_awvalid;
+    wire        imsic_s_axi_awready;
+    
+    wire [31:0] imsic_s_axi_wdata;
+    wire [3:0]  imsic_s_axi_wstrb;
+    wire        imsic_s_axi_wvalid;
+    wire        imsic_s_axi_wready;
+    
+    wire [1:0]  imsic_s_axi_bresp;
+    wire        imsic_s_axi_bvalid;
+    wire        imsic_s_axi_bready;
+    
+    wire [11:0] imsic_s_axi_araddr;
+    wire        imsic_s_axi_arvalid;
+    wire        imsic_s_axi_arready;
+    
+    wire [31:0] imsic_s_axi_rdata;
+    wire [1:0]  imsic_s_axi_rresp;
+    wire        imsic_s_axi_rvalid;
+    wire        imsic_s_axi_rready;
+
+    // INSTANTIATE IMSIC HERE and stop driving wires above
+    noc_axilite_bridge #(
+        .SLAVE_RESP_BYTEWIDTH   (4),
+        .SWAP_ENDIANESS         (1)
+    ) noc_ethernet_bridge (
+        .clk                    (net_axi_clk        ),
+        .rst                    (~rst_n             ),
+    
+        .splitter_bridge_val    (splitter_dst1_vr_noc1_val),
+        .splitter_bridge_data   (splitter_dst1_vr_noc1_dat),
+        .bridge_splitter_rdy    (splitter_dst1_vr_noc1_rdy),
+    
+        .bridge_splitter_val    (src1_merger_vr_noc2_val),
+        .bridge_splitter_data   (src1_merger_vr_noc2_dat),
+        .splitter_bridge_rdy    (src1_merger_vr_noc2_rdy),
+    
+        //axi lite signals
+        //write address channel
+        .m_axi_awaddr        (imsic_s_axi_awaddr),
+        .m_axi_awvalid       (imsic_s_axi_awvalid),
+        .m_axi_awready       (imsic_s_axi_awready),
+    
+        //write data channel
+        .m_axi_wdata         (imsic_s_axi_wdata),
+        .m_axi_wstrb         (imsic_s_axi_wstrb),
+        .m_axi_wvalid        (imsic_s_axi_wvalid),
+        .m_axi_wready        (imsic_s_axi_wready),
+    
+        //read address channelimsic
+        .m_axi_araddr        (imsic_s_axi_araddr),
+        .m_axi_arvalid       (imsic_s_axi_arvalid),
+        .m_axi_arready       (imsic_s_axi_arready),
+    
+        //read data channel
+        .m_axi_rdata         (imsic_s_axi_rdata),
+        .m_axi_rresp         (imsic_s_axi_rresp),
+        .m_axi_rvalid        (imsic_s_axi_rvalid),
+        .m_axi_rready        (imsic_s_axi_rready),
+    
+        //write response channel
+        .m_axi_bresp         (imsic_s_axi_bresp),
+        .m_axi_bvalid        (imsic_s_axi_bvalid),
+        .m_axi_bready        (imsic_s_axi_bready)
+    );
 
     //////////
     // L1.5 //
@@ -1125,21 +1335,20 @@ print(str)
 
         .transducer_l15_req_ack             (transducer_l15_req_ack),
 
-
-        .noc1_out_rdy(router_processor_ready_noc1),
-        .noc2_in_val(buffer_processor_valid_noc2),
-        .noc2_in_data(buffer_processor_data_noc2),
-        .noc3_out_rdy(router_processor_ready_noc3),
         .dmbr_l15_stall(dmbr_l15_stall),
         .chipid(config_chipid),
         .coreid_x(config_coreid_x),
         .coreid_y(config_coreid_y),
 
-        .noc1_out_val(processor_router_valid_noc1),
-        .noc1_out_data(processor_router_data_noc1),
-        .noc2_in_rdy(processor_router_ready_noc2),
-        .noc3_out_val(processor_router_valid_noc3),
-        .noc3_out_data(processor_router_data_noc3),
+        .noc1_out_rdy(processor_merger_vr_noc1_rdy),
+        .noc1_out_val(processor_merger_vr_noc1_val),
+        .noc1_out_data(processor_merger_vr_noc1_dat),
+        .noc2_in_val(splitter_processor_vr_noc2_val),
+        .noc2_in_data(splitter_processor_vr_noc2_dat),
+        .noc2_in_rdy(splitter_processor_vr_noc2_rdy),
+        .noc3_out_rdy(processor_merger_vr_noc3_rdy),
+        .noc3_out_val(processor_merger_vr_noc3_val),
+        .noc3_out_data(processor_merger_vr_noc3_dat),
         .l15_dmbr_l1missIn(l15_dmbr_l1missIn),
         .l15_dmbr_l1missTag(l15_dmbr_l1missTag),
         .l15_dmbr_l2missIn(l15_dmbr_l2missIn),
@@ -1219,16 +1428,16 @@ print(str)
         .chipid(config_chipid),
         .coreid_x(config_coreid_x),
         .coreid_y(config_coreid_y),
-        .noc1_valid_in(buffer_processor_valid_noc1),
-        .noc3_valid_in(buffer_processor_valid_noc3),
-        .noc1_data_in(buffer_processor_data_noc1),
-        .noc3_data_in(buffer_processor_data_noc3),
-        .noc2_ready_out(router_processor_ready_noc2),
-
-        .noc1_ready_in(processor_router_ready_noc1),
-        .noc3_ready_in(processor_router_ready_noc3),
-        .noc2_valid_out(processor_router_valid_noc2),
-        .noc2_data_out(processor_router_data_noc2),
+        .noc1_valid_in(splitter_processor_vr_noc1_val),
+        .noc3_valid_in(splitter_processor_vr_noc3_val),
+        .noc1_data_in( splitter_processor_vr_noc1_dat),
+        .noc3_data_in( splitter_processor_vr_noc3_dat),
+        .noc2_ready_out(processor_merger_vr_noc2_rdy),
+        
+        .noc1_ready_in(splitter_processor_vr_noc1_rdy),
+        .noc3_ready_in(splitter_processor_vr_noc3_rdy),
+        .noc2_valid_out(processor_merger_vr_noc2_val),
+        .noc2_data_out(processor_merger_vr_noc2_dat),
 
         // interface to srams
         .srams_rtap_data (l2_rtap_data),

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -1332,7 +1332,7 @@ print(str)
         .SLAVE_RESP_BYTEWIDTH   (4),
         .SWAP_ENDIANESS         (1)
     ) noc_ethernet_bridge (
-        .clk                    (net_axi_clk        ),
+        .clk                    (clk        ),
         .rst                    (~rst_n             ),
     
         .splitter_bridge_val    (splitter_dst1_vr_noc1_val),

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -1215,52 +1215,52 @@ print(str)
     assign src1_merger_vr_noc1_val = 1'b0;  
     assign src1_merger_vr_noc1_dat = 64'd0;
 
-    wire [11:0] imsic_s_axi_awaddr;
-    wire        imsic_s_axi_awvalid;
-    wire        imsic_s_axi_awready;
-    
-    wire [31:0] imsic_s_axi_wdata;
-    wire [3:0]  imsic_s_axi_wstrb;
-    wire        imsic_s_axi_wvalid;
-    wire        imsic_s_axi_wready;
-    
-    wire [1:0]  imsic_s_axi_bresp;
-    wire        imsic_s_axi_bvalid;
-    wire        imsic_s_axi_bready;
-    
-    wire [11:0] imsic_s_axi_araddr;
-    wire        imsic_s_axi_arvalid;
-    wire        imsic_s_axi_arready;
-    
-    wire [31:0] imsic_s_axi_rdata;
-    wire [1:0]  imsic_s_axi_rresp;
-    wire        imsic_s_axi_rvalid;
-    wire        imsic_s_axi_rready;
-
-    ariane_axi::req_t  msi_req;
-    ariane_axi::resp_t msi_resp;
-
-    assign msi_req.aw_valid    = imsic_s_axi_awvalid;
-    assign msi_req.aw.addr     = imsic_s_axi_awaddr;
-    assign imsic_s_axi_awready = msi_resp.aw_ready;
-
-    assign msi_req.w_valid    = imsic_s_axi_wvalid;
-    assign msi_req.w.data     = imsic_s_axi_wdata;
-    assign msi_req.w.strb     = imsic_s_axi_wstrb;
-    assign imsic_s_axi_wready = msi_resp.w_ready;
-
-    assign msi_req.ar_valid    = imsic_s_axi_arvalid;
-    assign msi_req.ar.addr     = imsic_s_axi_araddr;
-    assign imsic_s_axi_arready = msi_resp.ar_ready;    
-
-    assign msi_req.r_ready    = imsic_s_axi_rready;
-    assign imsic_s_axi_rvalid = msi_resp.r_valid;     
-    assign imsic_s_axi_rdata  = msi_resp.r.data;     
-    assign imsic_s_axi_rresp  = msi_resp.r.resp;   
-
-    assign msi_req.b_ready    = imsic_s_axi_bready;
-    assign imsic_s_axi_bvalid = msi_resp.b_valid;
-    assign imsic_s_axi_bresp  = msi_resp.b.resp;
+//    wire [11:0] imsic_s_axi_awaddr;
+//    wire        imsic_s_axi_awvalid;
+//    wire        imsic_s_axi_awready;
+//    
+//    wire [31:0] imsic_s_axi_wdata;
+//    wire [3:0]  imsic_s_axi_wstrb;
+//    wire        imsic_s_axi_wvalid;
+//    wire        imsic_s_axi_wready;
+//    
+//    wire [1:0]  imsic_s_axi_bresp;
+//    wire        imsic_s_axi_bvalid;
+//    wire        imsic_s_axi_bready;
+//    
+//    wire [11:0] imsic_s_axi_araddr;
+//    wire        imsic_s_axi_arvalid;
+//    wire        imsic_s_axi_arready;
+//    
+//    wire [31:0] imsic_s_axi_rdata;
+//    wire [1:0]  imsic_s_axi_rresp;
+//    wire        imsic_s_axi_rvalid;
+//    wire        imsic_s_axi_rready;
+//
+      ariane_axi::req_t  msi_req;
+      ariane_axi::resp_t msi_resp;
+//
+//    assign msi_req.aw_valid    = imsic_s_axi_awvalid;
+//    assign msi_req.aw.addr     = imsic_s_axi_awaddr;
+//    assign imsic_s_axi_awready = msi_resp.aw_ready;
+//
+//    assign msi_req.w_valid    = imsic_s_axi_wvalid;
+//    assign msi_req.w.data     = imsic_s_axi_wdata;
+//    assign msi_req.w.strb     = imsic_s_axi_wstrb;
+//    assign imsic_s_axi_wready = msi_resp.w_ready;
+//
+//    assign msi_req.ar_valid    = imsic_s_axi_arvalid;
+//    assign msi_req.ar.addr     = imsic_s_axi_araddr;
+//    assign imsic_s_axi_arready = msi_resp.ar_ready;    
+//
+//    assign msi_req.r_ready    = imsic_s_axi_rready;
+//    assign imsic_s_axi_rvalid = msi_resp.r_valid;     
+//    assign imsic_s_axi_rdata  = msi_resp.r.data;     
+//    assign imsic_s_axi_rresp  = msi_resp.r.resp;   
+//
+//    assign msi_req.b_ready    = imsic_s_axi_bready;
+//    assign imsic_s_axi_bvalid = msi_resp.b_valid;
+//    assign imsic_s_axi_bresp  = msi_resp.b.resp;
 
     // INSTANTIATE IMSIC HERE and stop driving wires above
     imsic_top # (
@@ -1269,7 +1269,6 @@ print(str)
         .NR_INTP_FILES     ( 2                  ),
         .AXI_ADDR_WIDTH    ( 32                 ),
         .AXI_DATA_WIDTH    ( 32                 ),
-        .AXI_ID_WIDTH      ( 10                 ),
         .axi_req_t         ( ariane_axi::req_t  ),
         .axi_resp_t        ( ariane_axi::resp_t ),   
     ) imsic (
@@ -1308,31 +1307,31 @@ print(str)
     
         //axi lite signals
         //write address channel
-        .m_axi_awaddr        (imsic_s_axi_awaddr),
-        .m_axi_awvalid       (imsic_s_axi_awvalid),
-        .m_axi_awready       (imsic_s_axi_awready),
+        .m_axi_awaddr        (msi_req.aw.addr),
+        .m_axi_awvalid       (msi_req.aw_valid),
+        .m_axi_awready       (msi_resp.aw_ready),
     
         //write data channel
-        .m_axi_wdata         (imsic_s_axi_wdata),
-        .m_axi_wstrb         (imsic_s_axi_wstrb),
-        .m_axi_wvalid        (imsic_s_axi_wvalid),
-        .m_axi_wready        (imsic_s_axi_wready),
+        .m_axi_wdata         (msi_req.w.data),
+        .m_axi_wstrb         (msi_req.w.strb),
+        .m_axi_wvalid        (msi_req.w_valid),
+        .m_axi_wready        (msi_resp.w_ready),
     
         //read address channelimsic
-        .m_axi_araddr        (imsic_s_axi_araddr),
-        .m_axi_arvalid       (imsic_s_axi_arvalid),
-        .m_axi_arready       (imsic_s_axi_arready),
+        .m_axi_araddr        (msi_req.ar.addr),
+        .m_axi_arvalid       (msi_req.ar_valid),
+        .m_axi_arready       (msi_resp.ar_ready),
     
         //read data channel
-        .m_axi_rdata         (imsic_s_axi_rdata),
-        .m_axi_rresp         (imsic_s_axi_rresp),
-        .m_axi_rvalid        (imsic_s_axi_rvalid),
-        .m_axi_rready        (imsic_s_axi_rready),
+        .m_axi_rdata         (msi_resp.r.data),
+        .m_axi_rresp         (msi_resp.r.resp),
+        .m_axi_rvalid        (msi_resp.r_valid),
+        .m_axi_rready        (msi_req.r_ready),
     
         //write response channel
-        .m_axi_bresp         (imsic_s_axi_bresp),
-        .m_axi_bvalid        (imsic_s_axi_bvalid),
-        .m_axi_bready        (imsic_s_axi_bready)
+        .m_axi_bresp         (msi_resp.b.resp),
+        .m_axi_bvalid        (msi_resp.b_valid),
+        .m_axi_bready        (msi_req.b_ready)
     );
 
     //////////

--- a/piton/design/chip/tile/rtl/tile.v.pyv
+++ b/piton/design/chip/tile/rtl/tile.v.pyv
@@ -1237,7 +1237,60 @@ print(str)
     wire        imsic_s_axi_rvalid;
     wire        imsic_s_axi_rready;
 
+    ariane_axi::req_t  msi_req;
+    ariane_axi::resp_t msi_resp;
+
+    assign msi_req.aw_valid    = imsic_s_axi_awvalid;
+    assign msi_req.aw.addr     = imsic_s_axi_awaddr;
+    assign imsic_s_axi_awready = msi_resp.aw_ready;
+
+    assign msi_req.w_valid    = imsic_s_axi_wvalid;
+    assign msi_req.w.data     = imsic_s_axi_wdata;
+    assign msi_req.w.strb     = imsic_s_axi_wstrb;
+    assign imsic_s_axi_wready = msi_resp.w_ready;
+
+    assign msi_req.ar_valid    = imsic_s_axi_arvalid;
+    assign msi_req.ar.addr     = imsic_s_axi_araddr;
+    assign imsic_s_axi_arready = msi_resp.ar_ready;    
+
+    assign msi_req.r_ready    = imsic_s_axi_rready;
+    assign imsic_s_axi_rvalid = msi_resp.r_valid;     
+    assign imsic_s_axi_rdata  = msi_resp.r.data;     
+    assign imsic_s_axi_rresp  = msi_resp.r.resp;   
+
+    assign msi_req.b_ready    = imsic_s_axi_bready;
+    assign imsic_s_axi_bvalid = msi_resp.b_valid;
+    assign imsic_s_axi_bresp  = msi_resp.b.resp;
+
     // INSTANTIATE IMSIC HERE and stop driving wires above
+    imsic_top # (
+        .NR_SRC            ( 32                 ),
+        .MIN_PRIO          ( 6                  ),
+        .NR_INTP_FILES     ( 2                  ),
+        .AXI_ADDR_WIDTH    ( 32                 ),
+        .AXI_DATA_WIDTH    ( 32                 ),
+        .AXI_ID_WIDTH      ( 10                 ),
+        .axi_req_t         ( ariane_axi::req_t  ),
+        .axi_resp_t        ( ariane_axi::resp_t ),   
+    ) imsic (
+        .i_clk             ( clk   ),
+        .ni_rst            ( rst_n ),
+       
+        .i_req             ( msi_req      ),
+        .o_resp            ( msi_resp     ),
+       
+        .i_priv_lvl        (       ),
+        .i_vgein           (       ),
+        .i_imsic_addr      (       ),
+        .i_imsic_data      (       ),
+        .i_imsic_we        (       ),
+        .i_imsic_claim     (       ),
+        .o_imsic_data      (       ),
+        .o_xtopei          (       ),
+        .o_Xeip_targets    (       ),
+        .o_imsic_exception (       )
+    );
+
     noc_axilite_bridge #(
         .SLAVE_RESP_BYTEWIDTH   (4),
         .SWAP_ENDIANESS         (1)

--- a/piton/design/chipset/axilite_noc_bridge/rtl/Flist.axilite_noc_bridge
+++ b/piton/design/chipset/axilite_noc_bridge/rtl/Flist.axilite_noc_bridge
@@ -1,0 +1,3 @@
+axilite_noc_bridge.sv
+noc_response_axilite.sv
+sync_fifo.v

--- a/piton/design/chipset/axilite_noc_bridge/rtl/axilite_noc_bridge.sv
+++ b/piton/design/chipset/axilite_noc_bridge/rtl/axilite_noc_bridge.sv
@@ -1,0 +1,803 @@
+// Copyright (c) 2019 multiple authors
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the authors nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+`include "define.tmp.h"
+
+module axilite_noc_bridge #(
+    parameter AXI_LITE_DATA_WIDTH = 64,
+    parameter AXI_LITE_ADDR_WIDTH = 64, 
+    parameter AXI_LITE_RESP_WIDTH = 2
+) (
+    input  logic                                   clk,
+    input  logic                                   rst_n,
+
+    output logic 		                           noc_valid_out,
+    output logic [`NOC_DATA_WIDTH-1:0] 		       noc_data_out,
+    input  logic 					               noc_ready_in,
+   
+    input  logic 					               noc_valid_in,
+    input  logic [`NOC_DATA_WIDTH-1:0] 		       noc_data_in,
+    output logic      				               noc_ready_out,
+
+    input  logic [`MSG_SRC_CHIPID_WIDTH-1:0]       src_chipid,
+    input  logic [`MSG_SRC_X_WIDTH-1:0]            src_xpos,
+    input  logic [`MSG_SRC_Y_WIDTH-1:0]            src_ypos,
+    input  logic [`MSG_SRC_FBITS_WIDTH-1:0]        src_fbits,
+
+    input  logic [`MSG_DST_CHIPID_WIDTH-1:0]       dest_chipid,
+    input  logic [`MSG_DST_X_WIDTH-1:0]            dest_xpos,
+    input  logic [`MSG_DST_Y_WIDTH-1:0]            dest_ypos,
+    input  logic [`MSG_DST_FBITS_WIDTH-1:0]        dest_fbits,
+  `ifndef ARA_REQ2MEM
+    input  logic [`HOME_ID_WIDTH-1:0]              system_tile_count,
+    input  logic [`HOME_ALLOC_METHOD_WIDTH-1:0]    home_alloc_method,
+  `endif 
+
+    // AXI Write Address Channel Signals
+    input  logic [AXI_LITE_ADDR_WIDTH-1:0]         m_axi_awaddr,
+    input  logic                                   m_axi_awvalid,
+    output logic                                   m_axi_awready,
+
+    // AXI Write Data Channel Signals
+    input  logic [AXI_LITE_DATA_WIDTH-1:0]         m_axi_wdata,
+    input  logic [AXI_LITE_DATA_WIDTH/8-1:0]       m_axi_wstrb,
+    input  logic                                   m_axi_wvalid,
+    output logic                                   m_axi_wready,
+
+    // AXI Read Address Channel Signals
+    input  logic [AXI_LITE_ADDR_WIDTH-1:0]         m_axi_araddr,
+    input  logic                                   m_axi_arvalid,
+    output logic                                   m_axi_arready,
+
+    // AXI Read Data Channel Signals
+    output logic [AXI_LITE_DATA_WIDTH-1:0]         m_axi_rdata,
+    output logic [AXI_LITE_RESP_WIDTH-1:0]         m_axi_rresp,
+    output logic                                   m_axi_rvalid,
+    input  logic                                   m_axi_rready,
+
+    // AXI Write Response Channel Signals
+    output logic [AXI_LITE_RESP_WIDTH-1:0]         m_axi_bresp,
+    output logic                                   m_axi_bvalid,
+    input  logic                                   m_axi_bready
+);
+
+// States for Incoming Piton Messages
+localparam MSG_TYPE_INVAL          = 2'd0; // Invalid Message
+localparam MSG_TYPE_LOAD           = 2'd1; // Load Request
+localparam MSG_TYPE_STORE          = 2'd2; // Store Request
+
+localparam MIN_NOC_DATA_WIDTH      = 64; // 8 Bytes
+localparam NOC_HDR_LEN             = 3;
+
+localparam NOC_PAYLOAD_LEN = (AXI_LITE_DATA_WIDTH < MIN_NOC_DATA_WIDTH) ?
+                        3'b1 : AXI_LITE_DATA_WIDTH / MIN_NOC_DATA_WIDTH;
+localparam NULL_PAYLOAD_LEN = 2; // we write 16 bytes null data for L2 version load request
+
+typedef enum logic [1:0] {
+    MSG_STATE_IDLE = 2'd0,
+
+  `ifdef ARA_REQ2MEM
+    MSG_STATE_WAIT_STRB = 2'd1,
+    MSG_STATE_HEADER = 2'd2,
+    MSG_STATE_NOC_DATA = 2'd3
+  `else 
+    MSG_STATE_DEST_CAL = 2'd1,
+    MSG_STATE_HEADER = 2'd2,
+    MSG_STATE_NOC_DATA = 2'd3
+  `endif
+} flit_state;        // state for flit output
+
+flit_state                                flit_state_f, flit_state_next;
+
+`ifdef ARA_REQ2MEM
+    typedef enum logic [1:0] {
+        IDLE = 2'd0,
+        VALID = 2'd1,
+        WAIT_ = 2'd2
+    } wstrb_fifo_state;  // state for strobe conversion 
+
+    wstrb_fifo_state                          wstrb_fifo_state_f, wstrb_fifo_state_next;
+`endif 
+
+/* flit fields */
+logic [`NOC_DATA_WIDTH-1:0]               msg_address;
+logic [`MSG_LENGTH_WIDTH-1:0]             msg_length;
+logic [`MSG_TYPE_WIDTH-1:0]               msg_type;
+logic [`MSG_MSHRID_WIDTH-1:0]             msg_mshrid;
+logic [`MSG_DATA_SIZE_WIDTH-1:0]          msg_data_size;
+logic [`MSG_OPTIONS_1]                    msg_options_1;
+logic [`MSG_OPTIONS_2_]                   msg_options_2;
+logic [`MSG_OPTIONS_3_]                   msg_options_3;
+
+logic                                     axi2noc_msg_type_store;
+logic                                     axi2noc_msg_type_load;
+logic                                     flit_ready;
+logic [`NOC_DATA_WIDTH-1:0]               flit;
+logic [`NOC_DATA_WIDTH-1:0]               noc_data;
+
+logic                                     type_fifo_wval;
+logic                                     type_fifo_full;
+logic [1:0]                               type_fifo_wdata;
+logic                                     type_fifo_empty;
+logic [1:0]                               type_fifo_out;
+logic                                     type_fifo_ren;
+
+logic                                     awaddr_fifo_wval;
+logic                                     awaddr_fifo_full;
+logic [AXI_LITE_ADDR_WIDTH-1:0]           awaddr_fifo_wdata;
+logic                                     awaddr_fifo_empty;
+logic [AXI_LITE_ADDR_WIDTH-1:0]           awaddr_fifo_out;
+logic                                     awaddr_fifo_ren;
+
+logic                                     wdata_fifo_wval;
+logic                                     wdata_fifo_full;
+logic [AXI_LITE_DATA_WIDTH-1:0]           wdata_fifo_wdata;
+logic                                     wdata_fifo_empty;
+logic [AXI_LITE_DATA_WIDTH-1:0]           wdata_fifo_out_buffer; // for endian conversion 
+logic [AXI_LITE_DATA_WIDTH-1:0]           wdata_fifo_out;
+logic                                     wdata_fifo_ren;
+
+logic                                     word_select;
+logic                                     araddr_fifo_wval;
+logic                                     araddr_fifo_full;
+logic [AXI_LITE_ADDR_WIDTH-1:0]           araddr_fifo_wdata;
+logic                                     araddr_fifo_empty;
+logic [AXI_LITE_ADDR_WIDTH-1:0]           araddr_fifo_out;
+logic                                     araddr_fifo_ren;
+
+logic [AXI_LITE_DATA_WIDTH/8 - 1: 0]      wstrb_fifo_out;
+logic [AXI_LITE_DATA_WIDTH/8 - 1: 0]      wstrb_fifo_wdata; 
+logic                                     wstrb_fifo_full;
+logic                                     wstrb_fifo_empty;
+logic                                     wstrb_fifo_ren;
+logic                                     wstrb_fifo_wval;
+
+logic [AXI_LITE_DATA_WIDTH/8 - 1: 0]      wstrb_fifo_mux_out;
+`ifdef ARA_REQ2MEM
+    logic [`MSG_DATA_SIZE_WIDTH - 1:0]        pmesh_data_size;
+    logic [$clog2(AXI_LITE_ADDR_WIDTH) - 1:0] pmesh_addr;
+    logic [`MSG_DATA_SIZE_WIDTH:0]            buf_pmesh_data_size;
+    logic [$clog2(AXI_LITE_ADDR_WIDTH) - 1:0] buf_pmesh_addr;
+    logic                                     wstrb_fifoside_valid;
+    logic                                     wstrb_fifoside_ready;
+    logic                                     wstrb_outputside_valid;
+    logic                                     wstrb_outputside_ready;
+`else 
+    logic                                     cal_dest_stage0;
+    logic                                     cal_dest_stage1; 
+    logic                                     cal_dest_stage2 ;
+    logic [`HOME_ID_WIDTH-1:0]                lhid_s0;
+    logic [`HOME_ID_WIDTH-1:0]                lhid_s1;
+    logic [`HOME_ID_WIDTH-1:0]                home_addr_bits_s0;
+    logic [`PHY_ADDR_WIDTH-1:0]               axilite2noc_req_address_s0;
+    logic                                     special_l2_addr_s0;
+    logic [`NOC_X_WIDTH-1:0]                  lhid_s1_x;
+    logic [`NOC_Y_WIDTH-1:0]                  lhid_s1_y;
+`endif
+
+logic                                     fifo_has_packet;
+logic                                     noc_store_done;
+logic                                     noc_load_done;
+logic [MIN_NOC_DATA_WIDTH-1:0]            out_data [0:NOC_PAYLOAD_LEN-1];
+logic                                     noc_last_header;
+logic                                     noc_last_data;
+logic [2:0]                               noc_cnt;
+
+logic                                     fifo_rst;
+
+// deal with simultaneous read write operation
+logic                                     simu_wr_detected; 
+logic                                     read_buffer_full; 
+
+/******** Where the magic happens ********/
+noc_response_axilite #(
+  `ifdef ARA_REQ2MEM
+    .AXILITE_DATA_WIDTH(AXI_LITE_DATA_WIDTH),
+    .AXI_RESP_WIDTH(2)
+  `else 
+    .AXILITE_DATA_WIDTH(AXI_LITE_DATA_WIDTH),
+    .AXI_RESP_WIDTH(2),
+    .MSG_TYPE_INVAL(MSG_TYPE_INVAL), 
+    .MSG_TYPE_STORE(MSG_TYPE_STORE), 
+    .MSG_TYPE_LOAD(MSG_TYPE_LOAD)
+  `endif
+) noc_response_axilite(
+    .clk(clk),
+    .rst_n(rst_n),
+    .noc_valid_in(noc_valid_in),
+    .noc_data_in(noc_data_in),
+    .noc_ready_out(noc_ready_out),
+  `ifndef ARA_REQ2MEM
+    .transaction_type_wr_data({1'b1, 1'b1, 1'b0, read_word_select, type_fifo_out}), 
+    .transaction_type_wr(type_fifo_ren),
+  `endif
+    .m_axi_rdata(m_axi_rdata),
+    .m_axi_rresp(m_axi_rresp),
+    .m_axi_rvalid(m_axi_rvalid),
+    .m_axi_rready(m_axi_rready),
+    .m_axi_bresp(m_axi_bresp),
+    .m_axi_bvalid(m_axi_bvalid),
+    .m_axi_bready(m_axi_bready)
+);
+
+assign fifo_rst = !rst_n;
+/**************************************************************************/
+/*control signal of store buffer, which is for simultaneous read and write*/
+/**************************************************************************/  
+assign simu_wr_detected = awaddr_fifo_wval && araddr_fifo_wval && !read_buffer_full;
+
+always@(posedge clk or negedge rst_n) begin 
+    if (!rst_n) begin 
+        read_buffer_full <= 0;
+    end 
+    else if (simu_wr_detected) begin
+        read_buffer_full <= 1;
+    end 
+    else if (type_fifo_wval) begin 
+        read_buffer_full <= 0;
+    end 
+    else begin 
+        read_buffer_full <= read_buffer_full;
+    end
+end 
+/****************************************************************************/
+
+assign write_channel_ready = !awaddr_fifo_full && !wdata_fifo_full && !wstrb_fifo_full;
+//assign m_axi_awready = write_channel_ready && !type_fifo_full && !read_buffer_full;
+assign m_axi_awready = !awaddr_fifo_full && !type_fifo_full && !read_buffer_full;
+//assign m_axi_wready = write_channel_ready && !type_fifo_full;
+assign m_axi_wready = !wdata_fifo_full && !wstrb_fifo_full && !type_fifo_full;
+assign m_axi_arready = !araddr_fifo_full && !type_fifo_full && !read_buffer_full;
+
+assign axi2noc_msg_type_store = m_axi_awvalid && (!read_buffer_full); //give priority to load request if read buffer has something
+assign axi2noc_msg_type_load = m_axi_arvalid || read_buffer_full;
+
+/* fifo for storing packet type */
+sync_fifo #(
+    .DSIZE(2),
+    .ASIZE(5),
+    .MEMSIZE(16) // should be 2 ^ (ASIZE-1)
+) type_fifo (
+    .rdata(type_fifo_out),
+    .empty(type_fifo_empty),
+    .clk(clk),
+    .ren(type_fifo_ren),
+    .wdata(type_fifo_wdata),
+    .full(type_fifo_full),
+    .wval(type_fifo_wval),
+    .reset(!rst_n)
+);
+
+assign type_fifo_wval = (axi2noc_msg_type_store || axi2noc_msg_type_load) && !type_fifo_full;
+assign type_fifo_ren = (noc_store_done | noc_load_done) && !type_fifo_empty;
+assign type_fifo_wdata = (axi2noc_msg_type_store) ? MSG_TYPE_STORE :
+                            (axi2noc_msg_type_load) ? MSG_TYPE_LOAD : MSG_TYPE_INVAL;
+
+/* fifo for storing addresses */
+sync_fifo #(
+    .DSIZE(AXI_LITE_ADDR_WIDTH),
+    .ASIZE(5),
+    .MEMSIZE(16) // should be 2 ^ (ASIZE-1)
+) awaddr_fifo (
+    .rdata(awaddr_fifo_out),
+    .empty(awaddr_fifo_empty),
+    .clk(clk),
+    .ren(awaddr_fifo_ren),
+    .wdata(awaddr_fifo_wdata),
+    .full(awaddr_fifo_full),
+    .wval(awaddr_fifo_wval),
+    .reset(fifo_rst)
+);
+logic write_word_select;
+assign write_word_select = (type_fifo_out == MSG_TYPE_STORE && awaddr_fifo_out[3] == 1) ? 1 : 0;
+assign awaddr_fifo_wval = m_axi_awvalid && m_axi_awready; 
+assign awaddr_fifo_wdata = m_axi_awaddr;
+assign awaddr_fifo_ren = (noc_store_done && !awaddr_fifo_empty);
+
+/* fifo for wdata */
+sync_fifo #(
+	.DSIZE(AXI_LITE_DATA_WIDTH),
+	.ASIZE(5),
+	.MEMSIZE(16) // should be 2 ^ (ASIZE-1)    
+) waddr_fifo (
+	.rdata(wdata_fifo_out_buffer),
+	.empty(wdata_fifo_empty),
+	.clk(clk),
+	.ren(wdata_fifo_ren),
+	.wdata(wdata_fifo_wdata),
+	.full(wdata_fifo_full),
+	.wval(wdata_fifo_wval),
+	.reset(fifo_rst)
+);
+
+assign wdata_fifo_out = {<<8{wdata_fifo_out_buffer}};
+assign wdata_fifo_wval = m_axi_wvalid && m_axi_wready;
+assign wdata_fifo_wdata = m_axi_wdata;
+assign wdata_fifo_ren = (noc_store_done && !wdata_fifo_empty);
+
+/****************/ 
+// declaration for strobe to mask conversion 
+// control intreface signal
+
+assign wstrb_fifo_mux_out = (wstrb_fifo_empty) ? 8'b0000_0000 : {<<1{wstrb_fifo_out}};
+
+sync_fifo #(
+	.DSIZE(AXI_LITE_DATA_WIDTH/8),
+	.ASIZE(5),
+	.MEMSIZE(16) // should be 2 ^ (ASIZE-1)
+) wstrb_fifo (
+	.rdata(wstrb_fifo_out),
+	.empty(wstrb_fifo_empty),
+	.clk(clk),
+	.ren(wstrb_fifo_ren),
+	.wdata(wstrb_fifo_wdata),
+	.full(wstrb_fifo_full),
+	.wval(wstrb_fifo_wval),
+	.reset(fifo_rst)
+);
+
+assign wstrb_fifo_ren = (noc_store_done && !wstrb_fifo_empty);
+assign wstrb_fifo_wval = m_axi_wvalid && m_axi_wready;
+assign wstrb_fifo_wdata = m_axi_wstrb;
+
+`ifdef ARA_REQ2MEM
+    strb2mask strb2mask_ins (
+        .clk (clk),
+        .rst (fifo_rst),
+        .m_axi_wstrb (wstrb_fifo_mux_out),
+        .pmesh_data_size (pmesh_data_size),
+        .pmesh_addr (pmesh_addr), 
+        .s_channel_valid (wstrb_fifoside_valid),
+        .s_channel_ready(wstrb_fifoside_ready),
+        .d_channel_ready(wstrb_outputside_ready), 
+        .d_channel_valid(wstrb_outputside_valid)
+    );
+
+    //valid state machine 
+    always_ff@ (posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            wstrb_fifo_state_f <= IDLE;
+        end
+        else begin
+            wstrb_fifo_state_f <= wstrb_fifo_state_next;
+        end
+    end
+
+    // flip flop output the strobe conversion module 
+    always_ff@(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            buf_pmesh_addr <= 0;
+            buf_pmesh_data_size <= 0;
+        end
+        else if ((flit_state_f == MSG_STATE_WAIT_STRB) & (wstrb_outputside_ready & wstrb_outputside_valid)) begin
+            buf_pmesh_addr <= pmesh_addr;
+            buf_pmesh_data_size <= pmesh_data_size;
+        end
+        else begin
+            buf_pmesh_addr <= buf_pmesh_addr;
+            buf_pmesh_data_size <= buf_pmesh_data_size;
+        end
+    end
+
+    //state transfer logic
+    always_comb 
+    begin
+        wstrb_fifo_state_next = wstrb_fifo_state_f;
+        unique case (wstrb_fifo_state_f)
+            IDLE: begin 
+                wstrb_fifo_state_next = (fifo_has_packet && type_fifo_out == MSG_TYPE_STORE) 
+                                            ? VALID : wstrb_fifo_state_f;
+            end 
+            VALID: begin 
+                wstrb_fifo_state_next = (wstrb_fifoside_ready) ? WAIT_ : wstrb_fifo_state_f;
+            end
+            WAIT_: begin 
+                wstrb_fifo_state_next = (noc_store_done) ? IDLE : wstrb_fifo_state_f;
+            end 
+            default: begin 
+                wstrb_fifo_state_next = wstrb_fifo_state_f;
+            end 
+        endcase 
+    end 
+
+    assign wstrb_outputside_ready = (flit_state_f == MSG_STATE_WAIT_STRB) && (type_fifo_out == MSG_TYPE_STORE);
+
+    //state output 
+    assign wstrb_fifoside_valid = (wstrb_fifo_state_f == VALID);
+
+`endif 
+
+
+/* fifo for read addr */
+sync_fifo #(
+	.DSIZE(AXI_LITE_ADDR_WIDTH),
+	.ASIZE(5),
+	.MEMSIZE(16) // should be 2 ^ (ASIZE-1)    
+) raddr_fifo (
+	.rdata(araddr_fifo_out),
+	.empty(araddr_fifo_empty),
+	.clk(clk),
+	.ren(araddr_fifo_ren),
+	.wdata(araddr_fifo_wdata),
+	.full(araddr_fifo_full),
+	.wval(araddr_fifo_wval),
+	.reset(fifo_rst)
+);
+assign read_word_select = (type_fifo_out == MSG_TYPE_LOAD) ? (araddr_fifo_out[3]) : 0;  
+assign araddr_fifo_wval = m_axi_arvalid && m_axi_arready;
+assign araddr_fifo_wdata = m_axi_araddr;
+assign araddr_fifo_ren = (noc_load_done && !araddr_fifo_empty);
+
+/* 
+start the state machine when fifo is not empty and noc is ready 
+We need to toggle between address and data fifos.
+*/
+
+/*write channel ready: address, data, strobe, read channel ready: address */
+assign fifo_has_packet = (type_fifo_out == MSG_TYPE_STORE) ? (!awaddr_fifo_empty && !wdata_fifo_empty && !wstrb_fifo_empty) :
+                            (type_fifo_out == MSG_TYPE_LOAD) ? !araddr_fifo_empty : 1'b0;
+
+`ifdef ARA_REQ2MEM
+ assign noc_store_done = noc_last_data && type_fifo_out == MSG_TYPE_STORE && ~wstrb_outputside_valid;
+ assign noc_load_done = noc_last_header && type_fifo_out == MSG_TYPE_LOAD;
+
+`else // load now can be done with load_noshare message type 
+ assign noc_store_done = noc_last_data && type_fifo_out == MSG_TYPE_STORE;
+ assign noc_load_done = noc_last_header && type_fifo_out == MSG_TYPE_LOAD;
+
+// `else // this section is commented since we don't need extra data flit to use swap write back as the replacement of load_noshare
+//  assign noc_store_done = noc_last_data && type_fifo_out == MSG_TYPE_STORE; // L2 supports mask   
+//  assign noc_load_done = noc_last_data && type_fifo_out == MSG_TYPE_LOAD; // We need to file 2 meaningless data flit (16 bytes) for swap_wb load
+`endif
+
+generate begin
+ genvar k;
+ if (AXI_LITE_DATA_WIDTH < MIN_NOC_DATA_WIDTH) begin
+     for (k=0; k< MIN_NOC_DATA_WIDTH/AXI_LITE_DATA_WIDTH; k = k + 1)
+     begin: DATA_GEN
+         assign out_data[(k+1)*AXI_LITE_DATA_WIDTH-1 : k*AXI_LITE_DATA_WIDTH] = wdata_fifo_out;
+     end
+ end
+ else begin
+     for (k=0; k<NOC_PAYLOAD_LEN; k = k + 1)
+     begin: DATA_GEN
+         assign out_data[k] = wdata_fifo_out[(k+1)*MIN_NOC_DATA_WIDTH-1 : k*MIN_NOC_DATA_WIDTH];
+     end
+ end
+end
+endgenerate
+
+
+
+/* set defaults for the flit */
+always_comb
+begin
+    msg_type = `MSG_TYPE_RESERVED;
+    msg_data_size = `MSG_DATA_SIZE_8B;
+    msg_length = `MSG_LENGTH_WIDTH'b0;
+    msg_address = {{`MSG_ADDR_WIDTH-`PHY_ADDR_WIDTH{1'b0}}, {`PHY_ADDR_WIDTH{1'b0}}}; 
+    unique case (type_fifo_out)
+        MSG_TYPE_STORE: begin
+        `ifdef ARA_REQ2MEM
+            msg_type = `MSG_TYPE_NC_STORE_REQ; // axilite peripheral is writing to the memory?
+            msg_data_size = buf_pmesh_data_size; // fix it for now
+            msg_address = {{`MSG_ADDR_WIDTH-`PHY_ADDR_WIDTH{1'b0}}, awaddr_fifo_out[`PHY_ADDR_WIDTH-1:3], buf_pmesh_addr[2:0]};
+            msg_length = `MSG_LENGTH_WIDTH'd2 + NOC_PAYLOAD_LEN; // 2 extra headers + 1 data
+        `else 
+            msg_type = `MSG_TYPE_SWAPWB_REQ;
+            msg_data_size = `MSG_DATA_SIZE_16B; // fix it for now
+            msg_address = {{`MSG_ADDR_WIDTH-`PHY_ADDR_WIDTH{1'b0}}, awaddr_fifo_out[`PHY_ADDR_WIDTH-1:0]};
+            msg_length = `MSG_LENGTH_WIDTH'd2 + 2;
+        `endif
+        end
+
+        MSG_TYPE_LOAD: begin
+        `ifdef ARA_REQ2MEM // to memeory 
+            msg_type = `MSG_TYPE_NC_LOAD_REQ; 
+            msg_data_size = `MSG_DATA_SIZE_8B; 
+            msg_length = `MSG_LENGTH_WIDTH'd2; 
+            msg_address = {{`MSG_ADDR_WIDTH-`PHY_ADDR_WIDTH{1'b0}}, araddr_fifo_out[`PHY_ADDR_WIDTH-1:0]};
+        `else // we can use load noshare to load the data from L2 right now
+            msg_type = `MSG_TYPE_LOAD_NOSHARE_REQ; // for L2 LOADNOSHARE test 
+            msg_data_size = `MSG_DATA_SIZE_16B; // Noted that L2 still return 16 bytes data 
+            msg_length = `MSG_LENGTH_WIDTH'd2; 
+            msg_address = {{`MSG_ADDR_WIDTH-`PHY_ADDR_WIDTH{1'b0}}, araddr_fifo_out[`PHY_ADDR_WIDTH-1:0]};
+        // `else  // we don;t need to use swap writeback right now
+        //     msg_type = `MSG_TYPE_SWAPWB_REQ;
+        //     msg_data_size = `MSG_DATA_SIZE_16B; 
+        //     msg_length = `MSG_LENGTH_WIDTH'd2 + NULL_PAYLOAD_LEN; // 2 extra header and two extra data (16Bytes zero data)
+        //     msg_address = {{`MSG_ADDR_WIDTH-`PHY_ADDR_WIDTH{1'b0}}, araddr_fifo_out[`PHY_ADDR_WIDTH-1:0]};
+        `endif
+        end
+        MSG_TYPE_INVAL: begin 
+            msg_type = `MSG_TYPE_RESERVED;
+            msg_data_size = `MSG_DATA_SIZE_8B;
+            msg_length = `MSG_LENGTH_WIDTH'b0;
+            msg_address = {{`MSG_ADDR_WIDTH-`PHY_ADDR_WIDTH{1'b0}}, {`PHY_ADDR_WIDTH{1'b0}}}; 
+        end
+        default: begin
+            msg_type = `MSG_TYPE_RESERVED;
+            msg_data_size = `MSG_DATA_SIZE_8B;
+            msg_length = `MSG_LENGTH_WIDTH'b0;
+            msg_address = {{`MSG_ADDR_WIDTH-`PHY_ADDR_WIDTH{1'b0}}, {`PHY_ADDR_WIDTH{1'b0}}}; 
+        end
+    endcase
+end
+
+always_ff@(posedge clk or negedge rst_n)
+begin
+    if (!rst_n) begin
+        noc_cnt <= 3'b0;
+    end
+    else begin
+        noc_cnt <= (noc_last_header | noc_last_data)  ? 3'b0 :
+                    (noc_cnt == 3'b0 && fifo_has_packet) ? noc_cnt + 1: // since ready signal of NoC spilitter depends on producer's valid sinal, we need to let flit header0 ready first
+                    (fifo_has_packet && noc_ready_in) ? noc_cnt + 1 : noc_cnt;
+    end
+end
+
+
+
+always_comb
+begin
+    if (noc_ready_in) begin
+        noc_last_header = (flit_state_f == MSG_STATE_HEADER &&
+                                    noc_cnt == NOC_HDR_LEN) ? 1'b1 : 1'b0;
+        noc_last_data = (flit_state_f == MSG_STATE_NOC_DATA &&
+                                    noc_cnt == (msg_length - NOC_HDR_LEN )) ? 1'b1 : 1'b0;
+    end
+    else begin 
+        noc_last_header = 1'b0;
+        noc_last_data = 1'b0;
+    end 
+end
+
+
+always@(posedge clk or negedge rst_n) 
+begin 
+    if (!rst_n) begin
+        flit_state_f <= MSG_STATE_IDLE;
+    end
+    else begin
+        flit_state_f <= flit_state_next;
+    end
+end 
+
+
+always_ff@(posedge clk or negedge rst_n)
+begin
+    flit_state_next = flit_state_f;
+    unique case (flit_state_f)
+        MSG_STATE_IDLE: begin
+          `ifdef ARA_REQ2MEM
+            if ((fifo_has_packet && type_fifo_out == MSG_TYPE_STORE))
+                flit_state_next = MSG_STATE_WAIT_STRB;
+            else if ((fifo_has_packet && type_fifo_out == MSG_TYPE_LOAD))
+                flit_state_next = MSG_STATE_HEADER;
+          `else 
+            if (fifo_has_packet && ((type_fifo_out == MSG_TYPE_STORE) || (type_fifo_out == MSG_TYPE_LOAD)))
+                flit_state_next = MSG_STATE_DEST_CAL;
+          `endif 
+            else flit_state_next = flit_state_f;
+        end
+      `ifdef ARA_REQ2MEM
+        MSG_STATE_WAIT_STRB:begin
+            if (wstrb_outputside_ready & wstrb_outputside_valid)
+                flit_state_next = MSG_STATE_HEADER;
+            else flit_state_next = flit_state_f;
+        end
+      `else 
+        MSG_STATE_DEST_CAL: begin
+            flit_state_next = MSG_STATE_HEADER;
+        end
+      `endif
+      
+        MSG_STATE_HEADER: begin
+            if (noc_last_header && type_fifo_out == MSG_TYPE_STORE)
+                flit_state_next = MSG_STATE_NOC_DATA;
+            else if (noc_last_header && type_fifo_out == MSG_TYPE_LOAD)
+              `ifdef ARA_REQ2MEM
+                flit_state_next = MSG_STATE_IDLE;
+              `else
+                flit_state_next = MSG_STATE_IDLE;
+            //   `else // we don;t need extra data flits for load right now 
+            //     flit_state_next = MSG_STATE_NOC_DATA;
+              `endif 
+            else flit_state_next = flit_state_f;
+        end
+
+        MSG_STATE_NOC_DATA: begin
+            if (noc_store_done)
+                flit_state_next = MSG_STATE_IDLE;
+            else if (noc_load_done)
+                flit_state_next = MSG_STATE_IDLE;
+            else 
+                flit_state_next = flit_state_f;
+        end
+        default: flit_state_next = MSG_STATE_IDLE;
+    endcase
+end
+
+/*****destination x and y index calculate*************/
+
+`ifndef ARA_REQ2MEM
+    l15_home_encoder    l15_home_encoder(
+    .home_in        (home_addr_bits_s0),
+    .num_homes      (system_tile_count),
+    .lhid_out       (lhid_s0)
+    );
+
+    flat_id_to_xy lhid_to_xy (
+        .flat_id(lhid_s1[`HOME_ID_WIDTH-1:0]),
+        .x_coord(lhid_s1_x),
+        .y_coord(lhid_s1_y)
+    );
+
+    always_ff@(posedge clk or negedge rst_n) begin 
+        if (!rst_n) lhid_s1 <= `HOME_ID_WIDTH'b0;
+        else if (cal_dest_stage0) lhid_s1 <= lhid_s0;
+        else lhid_s1 <= lhid_s1;
+    end 
+
+    always_comb 
+    begin 
+        cal_dest_stage0 = (flit_state_f == MSG_STATE_IDLE);
+        cal_dest_stage1 = (flit_state_f == MSG_STATE_DEST_CAL);
+        cal_dest_stage2 = (flit_state_f == MSG_STATE_HEADER);
+    end 
+
+    always_comb
+    begin
+        //special l2 addresses start with 0xA
+        special_l2_addr_s0 = (axilite2noc_req_address_s0[39:36] == 4'b1010);
+    end
+
+    always_comb begin
+        unique case (type_fifo_out) 
+            MSG_TYPE_STORE: axilite2noc_req_address_s0 = awaddr_fifo_out[`PHY_ADDR_WIDTH-1:0];
+            MSG_TYPE_LOAD: axilite2noc_req_address_s0 = araddr_fifo_out[`PHY_ADDR_WIDTH-1:0];
+            MSG_TYPE_INVAL:axilite2noc_req_address_s0 = `PHY_ADDR_WIDTH'b0;
+            default: axilite2noc_req_address_s0 = `PHY_ADDR_WIDTH'b0;
+        endcase
+    end 
+
+    always_comb
+    begin
+        if (special_l2_addr_s0)
+        begin
+            home_addr_bits_s0 = axilite2noc_req_address_s0[`HOME_ID_ADDR_POS_HIGH];
+        end
+        else
+        begin
+            unique case (home_alloc_method) 
+            `HOME_ALLOC_LOW_ORDER_BITS:
+            begin
+                home_addr_bits_s0 = axilite2noc_req_address_s0[`HOME_ID_ADDR_POS_LOW];
+            end
+            `HOME_ALLOC_MIDDLE_ORDER_BITS:
+            begin
+                home_addr_bits_s0 = axilite2noc_req_address_s0[`HOME_ID_ADDR_POS_MIDDLE];
+            end
+            `HOME_ALLOC_HIGH_ORDER_BITS:
+            begin
+                home_addr_bits_s0 = axilite2noc_req_address_s0[`HOME_ID_ADDR_POS_HIGH];
+            end
+            `HOME_ALLOC_MIXED_ORDER_BITS:
+            begin
+                home_addr_bits_s0 = (axilite2noc_req_address_s0[`HOME_ID_ADDR_POS_LOW] ^ axilite2noc_req_address_s0[`HOME_ID_ADDR_POS_MIDDLE]);
+            end
+            default: home_addr_bits_s0 = `MSG_LHID_WIDTH'b0;
+            endcase
+        end
+    end
+`endif 
+
+always_comb
+begin
+    msg_mshrid = {`MSG_MSHRID_WIDTH{1'b0}};
+    msg_options_1 = {`MSG_OPTIONS_1_WIDTH{1'b0}};
+    msg_options_2 = 16'b0;
+    msg_options_3 = 30'b0;
+
+    flit[`MSG_OPTIONS_1] = msg_options_1;
+
+    flit[`MSG_AMO_MASK0_] = {`MSG_AMO_MASK0_WIDTH{1'b0}};
+    flit[`MSG_DATA_SIZE_] = msg_data_size;
+    flit[`MSG_OPTIONS_2_] = msg_options_2;
+
+    flit[`MSG_AMO_MASK1_] = {`MSG_AMO_MASK1_WIDTH{1'b0}};
+    flit[`MSG_OPTIONS_3_] = msg_options_2;
+
+    flit[`NOC_DATA_WIDTH -1:0] = {`NOC_DATA_WIDTH{1'b0}};
+    flit_ready = 1'b0;
+    unique case (flit_state_f)
+        MSG_STATE_HEADER: begin
+            unique case (noc_cnt)
+                3'b001: begin
+                    flit[`MSG_DST_CHIPID] = dest_chipid;
+                  `ifdef ARA_REQ2MEM
+                    flit[`MSG_DST_X] = dest_xpos;
+                    flit[`MSG_DST_Y] = dest_ypos;
+                  `else 
+                    flit[`MSG_DST_X] = lhid_s1_x;
+                    flit[`MSG_DST_Y] = lhid_s1_y;
+                  `endif
+                    flit[`MSG_DST_FBITS] = dest_fbits; // to memory or L2 cache
+                    flit[`MSG_LENGTH] = msg_length;
+                    flit[`MSG_TYPE] = msg_type;
+                    flit[`MSG_MSHRID] = msg_mshrid;
+                    flit[`MSG_OPTIONS_1] = msg_options_1;
+                    flit_ready = 1'b1;
+                end
+
+                3'b010: begin
+                `ifdef ARA_REQ2MEM
+                    flit[`MSG_ADDR_] = msg_address;
+                    flit[`MSG_OPTIONS_2_] = msg_options_2;
+                    flit[`MSG_DATA_SIZE_] = msg_data_size;
+                `else 
+                    flit[`MSG_ADDR_] = msg_address;
+                    flit[`MSG_DATA_SIZE_] = msg_data_size;
+                    flit[`MSG_AMO_MASK0_] = (type_fifo_out == MSG_TYPE_STORE && (write_word_select == 0)) ? wstrb_fifo_mux_out : 8'b0;
+                `endif 
+                    flit_ready = 1'b1;                  
+                end
+
+                3'b011: begin
+                `ifdef ARA_REQ2MEM
+                    flit[`MSG_SRC_CHIPID_] = src_chipid;
+                    flit[`MSG_SRC_X_] = src_xpos;
+                    flit[`MSG_SRC_Y_] = src_ypos;
+                    flit[`MSG_SRC_FBITS_] = src_fbits;
+                    flit[`MSG_OPTIONS_3_] = msg_options_3;
+                `else 
+                    flit[`MSG_SRC_CHIPID_] = src_chipid;
+                    flit[`MSG_SRC_X_] = src_xpos;
+                    flit[`MSG_SRC_Y_] = src_ypos;
+                    flit[`MSG_SRC_FBITS_] = src_fbits;
+                    flit[`MSG_AMO_MASK1_] = (type_fifo_out == MSG_TYPE_STORE && (write_word_select == 1)) ? wstrb_fifo_mux_out : 8'b0;
+                `endif 
+                    flit_ready = 1'b1;
+                end
+            endcase
+        end
+
+        MSG_STATE_NOC_DATA: begin
+            flit[`NOC_DATA_WIDTH-1:0] = (type_fifo_out == MSG_TYPE_STORE) ? wdata_fifo_out : {`NOC_DATA_WIDTH{1'b0}}; //wdata_fifo_out;
+            //flit[`NOC_DATA_WIDTH-1:0] = (type_fifo_out == MSG_TYPE_STORE) ? out_data[noc_cnt] : {`NOC_DATA_WIDTH{1'b0}}; //wdata_fifo_out;
+            flit_ready = 1'b1;
+        end
+
+        default: begin
+            flit[`NOC_DATA_WIDTH-1:0] = {`NOC_DATA_WIDTH{1'b0}};
+            flit_ready = 1'b0;
+        end
+    endcase
+end
+
+assign noc_valid_out = flit_ready;
+assign noc_data_out = flit;
+
+endmodule 

--- a/piton/design/chipset/axilite_noc_bridge/rtl/noc_response_axilite.sv
+++ b/piton/design/chipset/axilite_noc_bridge/rtl/noc_response_axilite.sv
@@ -1,0 +1,285 @@
+// Copyright (c) 2019 multiple authors
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the authors nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+`include "define.tmp.h"
+
+module noc_response_axi_decoder (
+    input logic [5:0] current_flit_info,
+    output logic last_write_flit,
+    output logic last_read_transfer, 
+    output logic read_size,  
+    output logic read_word_select, 
+    output logic [1:0] flit_type
+);
+
+always_comb begin 
+    last_write_flit = current_flit_info[5];
+    last_read_transfer = current_flit_info[4];
+    read_size = current_flit_info[3];
+    read_word_select = current_flit_info[2];
+    flit_type = current_flit_info[1:0];
+end 
+
+endmodule 
+module noc_response_axilite #(
+    parameter AXILITE_DATA_WIDTH  = 64,
+  `ifndef ARA_REQ2MEM
+    parameter MSG_TYPE_INVAL       = 2'd0, // Invalid Message
+    parameter MSG_TYPE_LOAD        = 2'd1,// Load Request
+    parameter MSG_TYPE_STORE       = 2'd2, // Store Request
+  `endif
+    parameter AXI_RESP_WIDTH  = 2
+) (
+    // Clock + Reset
+    input  logic                                   clk,
+    input  logic                                   rst_n,
+
+    //NoC channel output 
+    input  logic                                   noc_valid_in,
+    input  logic [`NOC_DATA_WIDTH-1:0]             noc_data_in,
+    output logic                                   noc_ready_out,
+
+    //Signal to indicate current transaction type 
+  `ifndef ARA_REQ2MEM
+    input  logic [5:0]                             transaction_type_wr_data, 
+    input  logic                                   transaction_type_wr,
+  `endif
+
+    // AXI Read Data Channel Signals
+    output logic [AXILITE_DATA_WIDTH-1:0]              m_axi_rdata,
+    output logic [AXI_RESP_WIDTH-1:0]              m_axi_rresp,
+    output logic                                   m_axi_rvalid,
+    input  logic                                   m_axi_rready,
+
+    // AXI Write Response Channel Signals
+    output logic [AXI_RESP_WIDTH-1:0]              m_axi_bresp,
+    output logic                                   m_axi_bvalid,
+    input  logic                                   m_axi_bready
+);
+
+localparam LAST_TRANSFER_FLAG_WIDTH = 1; 
+
+typedef enum logic [2:0] {
+    NOC_IN_STATE_HEADER          = 2'b00, // Header 0
+    NOC_IN_STATE_READ_DATA       = 2'b01, // Data Lines
+    NOC_IN_STATE_STORE_ACK       = 2'b10  // for the fifo read when store happens
+} noc_in_state;
+
+noc_in_state noc_in_state_f, noc_in_state_next;
+
+// input flit information 
+logic noc_io_go;
+logic L2_request_ack; 
+
+// read data fifo signal 
+logic                                rdata_fifo_ren;
+logic                                rdata_fifo_full;
+logic                                rdata_fifo_empty;
+logic [(AXILITE_DATA_WIDTH + LAST_TRANSFER_FLAG_WIDTH - 1):0]             rdata_fifo_rdata;
+
+logic                                rdata_fifo_wval;
+logic [(AXILITE_DATA_WIDTH + LAST_TRANSFER_FLAG_WIDTH - 1):0]             rdata_fifo_wdata;  
+logic [AXILITE_DATA_WIDTH-1:0]           rdata_fifo_data;      
+logic [LAST_TRANSFER_FLAG_WIDTH - 1 :0] valid_last_read_transfer;    
+
+// input flit counter and length 
+logic [`MSG_LENGTH_WIDTH - 1:0] noc_in_count_f; 
+logic [`MSG_LENGTH_WIDTH - 1:0] noc_in_payload_len_f;
+logic [`MSG_LENGTH_WIDTH - 1:0] noc_in_count_next; 
+logic [`MSG_LENGTH_WIDTH - 1:0] noc_in_payload_len_next;
+
+logic fifo_rst;
+
+//decoder output 
+logic last_write_flit;
+logic last_read_transfer; // if current transfer is last one in transaction 
+logic read_size; // 0 -> 8B, 1 -> 16B 
+logic read_word_select; // if 8B, which word will be choose 
+logic [1:0] flit_type;
+
+logic [5:0] transaction_type_rd_data; 
+logic transaction_type_rd; 
+logic transaction_fifo_empty;
+logic transaction_fifo_full; 
+
+// fifo of storing flit status, for dealing with the input flit in order 
+sync_fifo #(
+    .DSIZE(6),
+    .ASIZE(5),
+    .MEMSIZE(16) // should be 2 ^ (ASIZE-1)
+) type_fifo (
+    .rdata(transaction_type_rd_data),
+    .empty(transaction_fifo_empty),
+    .clk(clk),
+    .ren(transaction_type_rd),
+    .wdata(transaction_type_wr_data),
+    .full(transaction_fifo_full),
+    .wval(transaction_type_wr),
+    .reset(fifo_rst)
+);
+
+// decoder for indicate flit status (is input flit last transfer (beat) in current AXI trasanction, is the input flit valid data 16B or 8B, etc) 
+noc_response_axi_decoder noc_response_axi_decoder (
+    .current_flit_info (transaction_type_rd_data),
+    .last_write_flit(last_write_flit), 
+    .last_read_transfer(last_read_transfer),
+    .read_size(read_size), 
+    .read_word_select(read_word_select), 
+    .flit_type(flit_type)
+);
+
+/* fifo for read data */
+sync_fifo #(
+	.DSIZE(AXILITE_DATA_WIDTH + LAST_TRANSFER_FLAG_WIDTH),
+	.ASIZE(5),
+	.MEMSIZE(16)  
+) rdata_fifo (
+	.rdata(rdata_fifo_rdata),
+	.empty(rdata_fifo_empty),
+	.clk(clk),
+	.ren(rdata_fifo_ren),
+	.wdata(rdata_fifo_wdata),
+	.full(rdata_fifo_full),
+	.wval(rdata_fifo_wval),
+	.reset(fifo_rst)
+);
+
+assign fifo_rst = !rst_n;
+
+always_comb begin 
+    if (!transaction_fifo_empty)
+        transaction_type_rd = ((noc_in_state_f == NOC_IN_STATE_READ_DATA) || (noc_in_state_f == NOC_IN_STATE_STORE_ACK)) && (noc_io_go && (noc_in_count_f == noc_in_payload_len_f - 1));
+    else 
+        transaction_type_rd = 0;
+end
+
+always_comb begin 
+    // valid_last_read_transfer = last_read_flit_16B ? (noc_in_count_f == 1) && (noc_in_state_f == NOC_IN_STATE_READ_DATA): 
+    //                             last_read_flit_8B_first ? (noc_in_count_f == 0) && (noc_in_state_f == NOC_IN_STATE_READ_DATA):
+    //                             last_read_flit_8B_second ? (noc_in_count_f == 1) && (noc_in_state_f == NOC_IN_STATE_READ_DATA):
+    //                             0;
+    valid_last_read_transfer = (~last_read_transfer) ? 0 : 
+                                read_size ? (noc_in_count_f == 1) && (noc_in_state_f == NOC_IN_STATE_READ_DATA) :
+                                read_word_select ? (noc_in_count_f == 1) && (noc_in_state_f == NOC_IN_STATE_READ_DATA) :
+                                (noc_in_count_f == 0) && (noc_in_state_f == NOC_IN_STATE_READ_DATA); 
+end 
+
+always_comb begin 
+    rdata_fifo_wdata = {valid_last_read_transfer, {noc_data_in[7:0], noc_data_in[15:8], noc_data_in[23:16], noc_data_in[31:24], 
+    noc_data_in[39:32], noc_data_in[47:40], noc_data_in[55:48], noc_data_in[63:56]}};
+    // rdata_fifo_wval = last_read_flit_16B ? (noc_in_count_f >= 0) && (noc_in_state_f == NOC_IN_STATE_READ_DATA) && noc_io_go: 
+    //                     last_read_flit_8B_first ? (noc_in_count_f == 0) && (noc_in_state_f == NOC_IN_STATE_READ_DATA) && noc_io_go:
+    //                     last_read_flit_8B_second ? (noc_in_count_f == 1) && (noc_in_state_f == NOC_IN_STATE_READ_DATA) && noc_io_go:
+    //                     0;
+    rdata_fifo_wval = read_size ? (noc_in_count_f >= 0) && (noc_in_state_f == NOC_IN_STATE_READ_DATA) && noc_io_go : 
+                        read_word_select ? (noc_in_count_f == 1) && (noc_in_state_f == NOC_IN_STATE_READ_DATA) && noc_io_go :
+                        (noc_in_count_f == 0) && (noc_in_state_f == NOC_IN_STATE_READ_DATA) && noc_io_go;
+end 
+
+always_comb begin 
+    rdata_fifo_ren = m_axi_rvalid && m_axi_rready;
+end 
+
+//state register 
+always_ff@(posedge clk or negedge rst_n) begin 
+    if (!rst_n) noc_in_state_f <= NOC_IN_STATE_HEADER;
+    else noc_in_state_f <= noc_in_state_next;
+end 
+
+assign noc_io_go = noc_valid_in && noc_ready_out;
+assign L2_request_ack = (noc_in_state_f == NOC_IN_STATE_HEADER) && (noc_data_in[`MSG_TYPE] == `MSG_TYPE_DATA_ACK);
+
+//state transition
+always_comb begin 
+    unique case (noc_in_state_f)
+        NOC_IN_STATE_HEADER: begin 
+            if (noc_io_go && (L2_request_ack)) begin 
+                if ((flit_type == MSG_TYPE_STORE) && ~transaction_fifo_empty) begin 
+                    noc_in_state_next = NOC_IN_STATE_STORE_ACK;
+                end 
+                else if ((flit_type == MSG_TYPE_LOAD) && ~transaction_fifo_empty) begin
+                    noc_in_state_next = NOC_IN_STATE_READ_DATA;
+                end 
+                else noc_in_state_next = NOC_IN_STATE_HEADER;
+            end 
+            else noc_in_state_next = noc_in_state_f;
+        end 
+
+        NOC_IN_STATE_READ_DATA: begin 
+            if (noc_io_go && noc_in_count_f == noc_in_payload_len_f -1)  noc_in_state_next = NOC_IN_STATE_HEADER;
+            else noc_in_state_next = noc_in_state_f;
+        end 
+
+        NOC_IN_STATE_STORE_ACK: begin 
+            if (noc_io_go && noc_in_count_f == noc_in_payload_len_f -1)  noc_in_state_next = NOC_IN_STATE_HEADER;
+            else noc_in_state_next = noc_in_state_f;
+        end 
+
+        default: 
+            noc_in_state_next =  NOC_IN_STATE_HEADER;
+    endcase
+end 
+
+always_ff@(posedge clk or negedge rst_n) begin
+    if (!rst_n) noc_in_count_f <= 0;
+    else noc_in_count_f <= noc_in_count_next;
+end 
+
+always_comb begin
+    if (noc_in_state_f == NOC_IN_STATE_HEADER) noc_in_count_next = 0;
+    else if (noc_in_state_f == NOC_IN_STATE_READ_DATA || noc_in_state_f == NOC_IN_STATE_STORE_ACK && noc_io_go) noc_in_count_next = noc_in_count_f + 1;
+    else noc_in_count_next = noc_in_count_f;
+end 
+
+always_ff@(posedge clk or negedge rst_n) begin  
+    if (!rst_n) noc_in_payload_len_f <= 0;
+    else noc_in_payload_len_f <= noc_in_payload_len_next;
+end 
+
+always_comb begin 
+    if (noc_in_state_f == NOC_IN_STATE_HEADER && noc_io_go) noc_in_payload_len_next = noc_data_in[`MSG_LENGTH];
+    else noc_in_payload_len_next = noc_in_payload_len_f;
+end 
+
+
+//AXI interface output 
+always_comb begin 
+    m_axi_bresp = {AXI_RESP_WIDTH{1'b0}};
+    m_axi_bvalid = (noc_in_state_f == NOC_IN_STATE_STORE_ACK) && noc_io_go && (noc_in_count_f == noc_in_payload_len_f -1) && last_write_flit;
+end 
+
+always_comb begin 
+    m_axi_rdata = m_axi_rvalid ? rdata_fifo_rdata[AXILITE_DATA_WIDTH - 1: 0] : 64'hca11_ab1e_badc_ab1e;
+    m_axi_rresp = m_axi_rvalid && m_axi_rready ? {AXI_RESP_WIDTH{1'b0}} : 2'b10;
+    m_axi_rvalid = !rdata_fifo_empty;
+end 
+
+// NoC interface
+always_comb begin   
+    noc_ready_out = !rdata_fifo_full;
+end 
+
+endmodule 

--- a/piton/design/chipset/axilite_noc_bridge/rtl/sync_fifo.v
+++ b/piton/design/chipset/axilite_noc_bridge/rtl/sync_fifo.v
@@ -1,0 +1,179 @@
+/*
+Copyright (c) 2015 Princeton University
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Princeton University nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY PRINCETON UNIVERSITY "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL PRINCETON UNIVERSITY BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+//==================================================================================================
+//  Filename      : sync_fifo.v
+//  Created On    : 2014-10-13
+//  Last Modified : 2014-10-13
+//  Revision      :
+//  Author        : Yaosheng Fu
+//  Company       : Princeton University
+//  Email         : yfu@princeton.edu
+//
+//  Description   : A replacement for async fifo in case it doesn't work
+//  Note          : It uses positive reset to be consistant with Sam's async fifo
+//
+//==================================================================================================
+
+
+module sync_fifo 
+    #(
+        parameter DSIZE = 64,
+        parameter ASIZE = 5,
+        parameter MEMSIZE = 16 // should be 2 ^ (ASIZE-1)
+    )
+    (
+        rdata, 
+        empty,
+        clk,
+        ren,
+        wdata,
+        full,
+        wval,
+        reset
+        );
+    
+    //Inputs and Outputs
+    output reg [DSIZE-1:0] 	rdata;
+    output reg			empty;
+    output reg			full;
+    input	[DSIZE-1:0]	wdata;
+    input			wval;
+    input			ren;
+    input			clk;
+    input 			reset;
+    
+    
+    reg [DSIZE-1:0] sync_buf_mem_f [MEMSIZE-1:0];
+    reg [ASIZE:0] sync_buf_counter_f;
+    reg [ASIZE:0] sync_buf_counter_next;
+    reg [ASIZE-2:0] sync_rd_ptr_f;
+    reg [ASIZE-2:0] sync_rd_ptr_next;
+    reg [ASIZE-2:0] sync_wr_ptr_f;
+    reg [ASIZE-2:0] sync_wr_ptr_next;
+    
+    always @ *
+    begin
+        empty = (sync_buf_counter_f == 0);
+        full =  (sync_buf_counter_f ==  MEMSIZE);
+    end
+    
+    always @ *
+    begin
+        if (reset)
+        begin
+            sync_buf_counter_next = 0;
+        end
+        else if ((wval && !full) && (ren && !empty))
+        begin
+            sync_buf_counter_next = sync_buf_counter_f;
+        end
+        else if (wval && !full)
+        begin
+            sync_buf_counter_next = sync_buf_counter_f + 1;
+        end
+        else if (ren && !empty)
+        begin
+            sync_buf_counter_next = sync_buf_counter_f - 1;
+        end
+        else
+        begin
+            sync_buf_counter_next = sync_buf_counter_f;
+        end
+    end
+    
+    
+    always @ (posedge clk)
+    begin
+        sync_buf_counter_f <= sync_buf_counter_next;
+    end
+    
+    
+    always @ *
+    begin
+        if (reset)
+        begin   
+            sync_rd_ptr_next = 0;
+        end
+        else if (ren && !empty)
+        begin
+            sync_rd_ptr_next = sync_rd_ptr_f + 1;
+        end
+        else
+        begin
+            sync_rd_ptr_next = sync_rd_ptr_f;
+        end
+    end
+    
+    always @ (posedge clk)
+    begin
+        sync_rd_ptr_f <= sync_rd_ptr_next;
+    end
+    
+    always @ *
+    begin
+        if (reset)
+        begin   
+            sync_wr_ptr_next = 0;
+        end
+        else if (wval && !full)
+        begin
+            sync_wr_ptr_next = sync_wr_ptr_f + 1;
+        end
+        else
+        begin
+            sync_wr_ptr_next = sync_wr_ptr_f;
+        end
+    end
+    
+    
+    always @ (posedge clk)
+    begin
+        sync_wr_ptr_f <= sync_wr_ptr_next;
+    end
+    
+    always @ *
+    begin
+        rdata = sync_buf_mem_f[sync_rd_ptr_f];
+    end
+    
+    always @ (posedge clk)
+    begin
+        if (wval && !full)
+        begin
+            sync_buf_mem_f[sync_wr_ptr_f] <= wdata;
+        end
+        else
+        begin 
+            sync_buf_mem_f[sync_wr_ptr_f] <= sync_buf_mem_f[sync_wr_ptr_f];
+        end
+    end
+    
+    
+    
+    endmodule
+    

--- a/piton/design/chipset/rtl/chipset.v
+++ b/piton/design/chipset/rtl/chipset.v
@@ -502,6 +502,34 @@ module chipset(
 `ifdef PITON_RV64_PLIC
     // PLIC
 ,    output  [`PITON_NUM_TILES*2-1:0]                       irq_o           // level sensitive IR lines, mip & sip (async)
+`elsif  PITON_RV64_APLIC
+// APLIC
+`ifdef DIRECT_MODE
+,   output [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]   irq_o   
+`else
+,   output wire [31:0]                          msi_noc1_axi_awaddr
+,   output wire                                 msi_noc1_axi_awvalid
+,   input  wire                                 noc1_msi_axi_awready
+  
+,   output wire [31:0]                          msi_noc1_axi_wdata
+,   output wire [3:0]                           msi_noc1_axi_wstrb
+,   output wire                                 msi_noc1_axi_wvalid
+,   input  wire                                 noc1_msi_axi_wready
+  
+,   input  wire [1:0]                           noc1_msi_axi_bresp
+,   input  wire                                 noc1_msi_axi_bvalid
+,   output wire                                 msi_noc1_axi_bready
+  
+,   output wire [31:0]                          msi_noc1_axi_araddr
+,   output wire                                 msi_noc1_axi_arvalid
+,   input  wire                                 noc1_msi_axi_arready
+  
+,   input  wire [31:0]                          noc1_msi_axi_rdata
+,   input  wire [1:0]                           noc1_msi_axi_rresp
+,   input  wire                                 noc1_msi_axi_rvalid
+,   output wire                                 msi_noc1_axi_rready
+`endif // DIRECT_MODE
+
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
 
@@ -1443,6 +1471,32 @@ chipset_impl_noc_power_test  chipset_impl (
     
     `ifdef PITON_RV64_PLIC
         ,.irq_o                  ( irq_o         )
+    `elsif PITON_RV64_APLIC
+    `ifdef DIRECT_MODE
+        ,.irq_o                  ( irq_o         )
+    `else
+        ,.msi_noc1_axi_awaddr    ( msi_noc1_axi_awaddr  )
+        ,.msi_noc1_axi_awvalid   ( msi_noc1_axi_awvalid )
+        ,.noc1_msi_axi_awready   ( noc1_msi_axi_awready )
+        
+        ,.msi_noc1_axi_wdata     ( msi_noc1_axi_wdata   )
+        ,.msi_noc1_axi_wstrb     ( msi_noc1_axi_wstrb   )
+        ,.msi_noc1_axi_wvalid    ( msi_noc1_axi_wvalid  )
+        ,.noc1_msi_axi_wready    ( noc1_msi_axi_wready  )
+        
+        ,.noc1_msi_axi_bresp     ( noc1_msi_axi_bresp   )
+        ,.noc1_msi_axi_bvalid    ( noc1_msi_axi_bvalid  )
+        ,.msi_noc1_axi_bready    ( msi_noc1_axi_bready  )
+        
+        ,.msi_noc1_axi_araddr    ( msi_noc1_axi_araddr  )
+        ,.msi_noc1_axi_arvalid   ( msi_noc1_axi_arvalid )
+        ,.noc1_msi_axi_arready   ( noc1_msi_axi_arready )
+        
+        ,.noc1_msi_axi_rdata     ( noc1_msi_axi_rdata   )
+        ,.noc1_msi_axi_rresp     ( noc1_msi_axi_rresp   )
+        ,.noc1_msi_axi_rvalid    ( noc1_msi_axi_rvalid  )
+        ,.msi_noc1_axi_rready    ( msi_noc1_axi_rready  )
+    `endif // ifdef DIRECT_MODE
     `endif // ifdef PITON_RV64_PLIC
     `endif // ifdef PITON_RV64_PLATFORM
 );

--- a/piton/design/chipset/rtl/chipset.v
+++ b/piton/design/chipset/rtl/chipset.v
@@ -506,28 +506,6 @@ module chipset(
 // APLIC
 `ifdef DIRECT_MODE
 ,   output [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]   irq_o   
-`else
-,   output wire [31:0]                          msi_noc1_axi_awaddr
-,   output wire                                 msi_noc1_axi_awvalid
-,   input  wire                                 noc1_msi_axi_awready
-  
-,   output wire [31:0]                          msi_noc1_axi_wdata
-,   output wire [3:0]                           msi_noc1_axi_wstrb
-,   output wire                                 msi_noc1_axi_wvalid
-,   input  wire                                 noc1_msi_axi_wready
-  
-,   input  wire [1:0]                           noc1_msi_axi_bresp
-,   input  wire                                 noc1_msi_axi_bvalid
-,   output wire                                 msi_noc1_axi_bready
-  
-,   output wire [31:0]                          msi_noc1_axi_araddr
-,   output wire                                 msi_noc1_axi_arvalid
-,   input  wire                                 noc1_msi_axi_arready
-  
-,   input  wire [31:0]                          noc1_msi_axi_rdata
-,   input  wire [1:0]                           noc1_msi_axi_rresp
-,   input  wire                                 noc1_msi_axi_rvalid
-,   output wire                                 msi_noc1_axi_rready
 `endif // DIRECT_MODE
 
 `endif // ifdef PITON_RV64_PLIC
@@ -1474,28 +1452,6 @@ chipset_impl_noc_power_test  chipset_impl (
     `elsif PITON_RV64_APLIC
     `ifdef DIRECT_MODE
         ,.irq_o                  ( irq_o         )
-    `else
-        ,.msi_noc1_axi_awaddr    ( msi_noc1_axi_awaddr  )
-        ,.msi_noc1_axi_awvalid   ( msi_noc1_axi_awvalid )
-        ,.noc1_msi_axi_awready   ( noc1_msi_axi_awready )
-        
-        ,.msi_noc1_axi_wdata     ( msi_noc1_axi_wdata   )
-        ,.msi_noc1_axi_wstrb     ( msi_noc1_axi_wstrb   )
-        ,.msi_noc1_axi_wvalid    ( msi_noc1_axi_wvalid  )
-        ,.noc1_msi_axi_wready    ( noc1_msi_axi_wready  )
-        
-        ,.noc1_msi_axi_bresp     ( noc1_msi_axi_bresp   )
-        ,.noc1_msi_axi_bvalid    ( noc1_msi_axi_bvalid  )
-        ,.msi_noc1_axi_bready    ( msi_noc1_axi_bready  )
-        
-        ,.msi_noc1_axi_araddr    ( msi_noc1_axi_araddr  )
-        ,.msi_noc1_axi_arvalid   ( msi_noc1_axi_arvalid )
-        ,.noc1_msi_axi_arready   ( noc1_msi_axi_arready )
-        
-        ,.noc1_msi_axi_rdata     ( noc1_msi_axi_rdata   )
-        ,.noc1_msi_axi_rresp     ( noc1_msi_axi_rresp   )
-        ,.noc1_msi_axi_rvalid    ( noc1_msi_axi_rvalid  )
-        ,.msi_noc1_axi_rready    ( msi_noc1_axi_rready  )
     `endif // ifdef DIRECT_MODE
     `endif // ifdef PITON_RV64_PLIC
     `endif // ifdef PITON_RV64_PLATFORM

--- a/piton/design/chipset/rtl/chipset_impl.v.pyv
+++ b/piton/design/chipset/rtl/chipset_impl.v.pyv
@@ -293,28 +293,6 @@ module chipset_impl(
 // APLIC
 `ifdef DIRECT_MODE
 ,   output [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]           irq_o   
-`else
-,   output wire [31:0]                          msi_noc1_axi_awaddr
-,   output wire                                 msi_noc1_axi_awvalid
-,   input  wire                                 noc2_msi_axi_awready
-  
-,   output wire [31:0]                          msi_noc1_axi_wdata
-,   output wire [3:0]                           msi_noc1_axi_wstrb
-,   output wire                                 msi_noc1_axi_wvalid
-,   input  wire                                 noc2_msi_axi_wready
-  
-,   input  wire [1:0]                           noc2_msi_axi_bresp
-,   input  wire                                 noc2_msi_axi_bvalid
-,   output wire                                 msi_noc1_axi_bready
-  
-,   output wire [31:0]                          msi_noc1_axi_araddr
-,   output wire                                 msi_noc1_axi_arvalid
-,   input  wire                                 noc2_msi_axi_arready
-  
-,   input  wire [31:0]                          noc2_msi_axi_rdata
-,   input  wire [1:0]                           noc2_msi_axi_rresp
-,   input  wire                                 noc2_msi_axi_rvalid
-,   output wire                                 msi_noc1_axi_rready
 `endif // DIRECT_MODE
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
@@ -1251,27 +1229,6 @@ str = '''
 `ifdef DIRECT_MODE
 ,       .irq_o                           ( irq_o                         )
 `else
-,       .msi_noc1_axi_awaddr             ( msi_noc1_axi_awaddr           )
-,       .msi_noc1_axi_awvalid            ( msi_noc1_axi_awvalid          )
-,       .noc2_msi_axi_awready            ( noc2_msi_axi_awready          )
-
-,       .msi_noc1_axi_wdata              ( msi_noc1_axi_wdata            )
-,       .msi_noc1_axi_wstrb              ( msi_noc1_axi_wstrb            )
-,       .msi_noc1_axi_wvalid             ( msi_noc1_axi_wvalid           )
-,       .noc2_msi_axi_wready             ( noc2_msi_axi_wready           )
-
-,       .noc2_msi_axi_bresp              ( noc2_msi_axi_bresp            )
-,       .noc2_msi_axi_bvalid             ( noc2_msi_axi_bvalid           )
-,       .msi_noc1_axi_bready             ( msi_noc1_axi_bready           )
-
-,       .msi_noc1_axi_araddr             ( msi_noc1_axi_araddr           )
-,       .msi_noc1_axi_arvalid            ( msi_noc1_axi_arvalid          )
-,       .noc2_msi_axi_arready            ( noc2_msi_axi_arready          )
-
-,       .noc2_msi_axi_rdata              ( noc2_msi_axi_rdata            )
-,       .noc2_msi_axi_rresp              ( noc2_msi_axi_rresp            )
-,       .noc2_msi_axi_rvalid             ( noc2_msi_axi_rvalid           )
-,       .msi_noc1_axi_rready             ( msi_noc1_axi_rready           )
 // MSI request to NoC1
 ,       .noc1_valid_out                  ( chipset_intf_val_noc1         )
 ,       .noc1_data_out                   ( chipset_intf_data_noc1        )
@@ -1279,7 +1236,7 @@ str = '''
 // NoC2 request to MSI
 ,       .noc2_valid_in                   ( intf_chipset_val_noc2         )
 ,       .noc2_data_in                    ( intf_chipset_data_noc2        )
-,       .noc2_ready_out                  ( msi_noc2_rdy                )
+,       .noc2_ready_out                  ( msi_noc2_rdy                  )
 `endif // `ifdef DIRECT_MODE 
 `endif // `ifdef PITON_RV64_PLIC
     );

--- a/piton/design/chipset/rtl/chipset_impl.v.pyv
+++ b/piton/design/chipset/rtl/chipset_impl.v.pyv
@@ -1189,14 +1189,14 @@ str = '''
 ,       .ariane_clint_buf_noc3_valid_o   ( ariane_clint_buf_noc3_valid   )
 ,       .buf_ariane_clint_noc3_ready_i   ( buf_ariane_clint_noc3_ready   )
 `endif // ifdef PITON_RV64_CLINT
-`ifdef PITON_RV64_PLIC
+//`ifdef PITON_RV64_PLIC
 ,       .buf_ariane_plic_noc2_data_i     ( buf_ariane_plic_noc2_data     )
 ,       .buf_ariane_plic_noc2_valid_i    ( buf_ariane_plic_noc2_valid    )
 ,       .ariane_plic_buf_noc2_ready_o    ( ariane_plic_buf_noc2_ready    )
 ,       .ariane_plic_buf_noc3_data_o     ( ariane_plic_buf_noc3_data     )
 ,       .ariane_plic_buf_noc3_valid_o    ( ariane_plic_buf_noc3_valid    )
 ,       .buf_ariane_plic_noc3_ready_i    ( buf_ariane_plic_noc3_ready    )
-`endif // ifdef PITON_RV64_PLIC
+//`endif // ifdef PITON_RV64_PLIC
         // This selects either the BM or linux bootrom
 ,       .ariane_boot_sel_i               ( ariane_boot_sel               )
 `ifdef PITON_RV64_DEBUGUNIT
@@ -1234,9 +1234,9 @@ str = '''
 ,       .noc1_data_out                   ( chipset_intf_data_noc1        )
 ,       .noc1_ready_in                   ( chipset_intf_rdy_noc1         )
 // NoC2 request to MSI
-,       .noc2_valid_in                   ( intf_chipset_val_noc2         )
-,       .noc2_data_in                    ( intf_chipset_data_noc2        )
-,       .noc2_ready_out                  ( msi_noc2_rdy                  )
+,       .noc2_valid_in                   ( buf_ariane_aia_noc2_val       )
+,       .noc2_data_in                    ( buf_ariane_aia_noc2_data      )
+,       .noc2_ready_out                  ( ariane_aia_buf_noc2_ready     )
 `endif // `ifdef DIRECT_MODE 
 `endif // `ifdef PITON_RV64_PLIC
     );

--- a/piton/design/chipset/rtl/chipset_impl.v.pyv
+++ b/piton/design/chipset/rtl/chipset_impl.v.pyv
@@ -296,29 +296,33 @@ module chipset_impl(
 `else
 ,   output wire [31:0]                          msi_noc1_axi_awaddr
 ,   output wire                                 msi_noc1_axi_awvalid
-,   input  wire                                 noc1_msi_axi_awready
+,   input  wire                                 noc2_msi_axi_awready
   
 ,   output wire [31:0]                          msi_noc1_axi_wdata
 ,   output wire [3:0]                           msi_noc1_axi_wstrb
 ,   output wire                                 msi_noc1_axi_wvalid
-,   input  wire                                 noc1_msi_axi_wready
+,   input  wire                                 noc2_msi_axi_wready
   
-,   input  wire [1:0]                           noc1_msi_axi_bresp
-,   input  wire                                 noc1_msi_axi_bvalid
+,   input  wire [1:0]                           noc2_msi_axi_bresp
+,   input  wire                                 noc2_msi_axi_bvalid
 ,   output wire                                 msi_noc1_axi_bready
   
 ,   output wire [31:0]                          msi_noc1_axi_araddr
 ,   output wire                                 msi_noc1_axi_arvalid
-,   input  wire                                 noc1_msi_axi_arready
+,   input  wire                                 noc2_msi_axi_arready
   
-,   input  wire [31:0]                          noc1_msi_axi_rdata
-,   input  wire [1:0]                           noc1_msi_axi_rresp
-,   input  wire                                 noc1_msi_axi_rvalid
+,   input  wire [31:0]                          noc2_msi_axi_rdata
+,   input  wire [1:0]                           noc2_msi_axi_rresp
+,   input  wire                                 noc2_msi_axi_rvalid
 ,   output wire                                 msi_noc1_axi_rready
 `endif // DIRECT_MODE
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
 );
+
+`ifdef MSI_MODE
+  wire msi_noc2_rdy;
+`endif // MSI_MODE
 
 ///////////////////////
 // Type declarations //
@@ -512,7 +516,7 @@ assign chip_buf_noc2_ready = chipset_intf_rdy_noc2;
 
 assign chip_filter_noc2_valid = intf_chipset_val_noc2;
 assign chip_filter_noc2_data = intf_chipset_data_noc2;
-assign intf_chipset_rdy_noc2    = (filter_chip_noc2_ready & cpu_mem_traffic) | msi_noc2_rdy;
+assign intf_chipset_rdy_noc2    = (filter_chip_noc2_ready & cpu_mem_traffic) /* | msi_noc2_rdy*/;
 
 // NoC 3
 assign chipset_intf_val_noc3    = cpu_mem_traffic & filter_chip_noc3_valid;
@@ -1157,7 +1161,6 @@ fake_uart fake_uart (
   `endif
 `endif
 
-  wire msi_noc2_rdy;
 <%
 DmBase    = 0
 RomBase   = 0
@@ -1250,24 +1253,24 @@ str = '''
 `else
 ,       .msi_noc1_axi_awaddr             ( msi_noc1_axi_awaddr           )
 ,       .msi_noc1_axi_awvalid            ( msi_noc1_axi_awvalid          )
-,       .noc1_msi_axi_awready            ( noc1_msi_axi_awready          )
+,       .noc2_msi_axi_awready            ( noc2_msi_axi_awready          )
 
 ,       .msi_noc1_axi_wdata              ( msi_noc1_axi_wdata            )
 ,       .msi_noc1_axi_wstrb              ( msi_noc1_axi_wstrb            )
 ,       .msi_noc1_axi_wvalid             ( msi_noc1_axi_wvalid           )
-,       .noc1_msi_axi_wready             ( noc1_msi_axi_wready           )
+,       .noc2_msi_axi_wready             ( noc2_msi_axi_wready           )
 
-,       .noc1_msi_axi_bresp              ( noc1_msi_axi_bresp            )
-,       .noc1_msi_axi_bvalid             ( noc1_msi_axi_bvalid           )
+,       .noc2_msi_axi_bresp              ( noc2_msi_axi_bresp            )
+,       .noc2_msi_axi_bvalid             ( noc2_msi_axi_bvalid           )
 ,       .msi_noc1_axi_bready             ( msi_noc1_axi_bready           )
 
 ,       .msi_noc1_axi_araddr             ( msi_noc1_axi_araddr           )
 ,       .msi_noc1_axi_arvalid            ( msi_noc1_axi_arvalid          )
-,       .noc1_msi_axi_arready            ( noc1_msi_axi_arready          )
+,       .noc2_msi_axi_arready            ( noc2_msi_axi_arready          )
 
-,       .noc1_msi_axi_rdata              ( noc1_msi_axi_rdata            )
-,       .noc1_msi_axi_rresp              ( noc1_msi_axi_rresp            )
-,       .noc1_msi_axi_rvalid             ( noc1_msi_axi_rvalid           )
+,       .noc2_msi_axi_rdata              ( noc2_msi_axi_rdata            )
+,       .noc2_msi_axi_rresp              ( noc2_msi_axi_rresp            )
+,       .noc2_msi_axi_rvalid             ( noc2_msi_axi_rvalid           )
 ,       .msi_noc1_axi_rready             ( msi_noc1_axi_rready           )
 // MSI request to NoC1
 ,       .noc1_valid_out                  ( chipset_intf_val_noc1         )

--- a/piton/design/chipset/rtl/chipset_impl.v.pyv
+++ b/piton/design/chipset/rtl/chipset_impl.v.pyv
@@ -289,6 +289,33 @@ module chipset_impl(
 `ifdef PITON_RV64_PLIC
     // PLIC
 ,   output [`PITON_NUM_TILES*2-1:0]             irq_o           // level sensitive IR lines, mip & sip (async)
+`elsif  PITON_RV64_APLIC
+// APLIC
+`ifdef DIRECT_MODE
+,   output [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]           irq_o   
+`else
+,   output wire [31:0]                          msi_noc1_axi_awaddr
+,   output wire                                 msi_noc1_axi_awvalid
+,   input  wire                                 noc1_msi_axi_awready
+  
+,   output wire [31:0]                          msi_noc1_axi_wdata
+,   output wire [3:0]                           msi_noc1_axi_wstrb
+,   output wire                                 msi_noc1_axi_wvalid
+,   input  wire                                 noc1_msi_axi_wready
+  
+,   input  wire [1:0]                           noc1_msi_axi_bresp
+,   input  wire                                 noc1_msi_axi_bvalid
+,   output wire                                 msi_noc1_axi_bready
+  
+,   output wire [31:0]                          msi_noc1_axi_araddr
+,   output wire                                 msi_noc1_axi_arvalid
+,   input  wire                                 noc1_msi_axi_arready
+  
+,   input  wire [31:0]                          noc1_msi_axi_rdata
+,   input  wire [1:0]                           noc1_msi_axi_rresp
+,   input  wire                                 noc1_msi_axi_rvalid
+,   output wire                                 msi_noc1_axi_rready
+`endif // DIRECT_MODE
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
 );
@@ -419,8 +446,8 @@ end
 
 // Currently NoC 1 from chipset to interface is not used
 // by any chipset implementation
-assign chipset_intf_data_noc1 = {`NOC_DATA_WIDTH{1'b0}};
-assign chipset_intf_val_noc1 = 1'b0;
+//assign chipset_intf_data_noc1 = {`NOC_DATA_WIDTH{1'b0}};
+//assign chipset_intf_val_noc1 = 1'b0;
 
 // Currently NoC 3 from interface to chipset is not used
 // by any chipset implementation
@@ -485,7 +512,7 @@ assign chip_buf_noc2_ready = chipset_intf_rdy_noc2;
 
 assign chip_filter_noc2_valid = intf_chipset_val_noc2;
 assign chip_filter_noc2_data = intf_chipset_data_noc2;
-assign intf_chipset_rdy_noc2    = filter_chip_noc2_ready & cpu_mem_traffic;
+assign intf_chipset_rdy_noc2    = (filter_chip_noc2_ready & cpu_mem_traffic) | msi_noc2_rdy;
 
 // NoC 3
 assign chipset_intf_val_noc3    = cpu_mem_traffic & filter_chip_noc3_valid;
@@ -1065,7 +1092,7 @@ assign uart_interrupt = 1'b0;
 
 // Fake iobridge
 // Tie noc1 input low because it's unused
-assign intf_chipset_rdy_noc1 = 1'b0;
+//assign intf_chipset_rdy_noc1 = 1'b0;
 ciop_fake_iob ciop_fake_iob(
     .noc_out_val       ( iob_filter_noc2_valid ),
     .noc_out_rdy       ( filter_iob_noc2_ready ),
@@ -1130,6 +1157,7 @@ fake_uart fake_uart (
   `endif
 `endif
 
+  wire msi_noc2_rdy;
 <%
 DmBase    = 0
 RomBase   = 0
@@ -1215,7 +1243,42 @@ str = '''
 ,       .irq_le_i                        ( irq_le                        ) // 0:level 1:edge
 ,       .irq_sources_i                   ( irq_sources                   )
 ,       .irq_o                           ( irq_o                         )
-`endif // ifdef PITON_RV64_PLIC
+`elsif PITON_RV64_APLIC
+,       .irq_sources_i                   ( irq_sources                   )
+`ifdef DIRECT_MODE
+,       .irq_o                           ( irq_o                         )
+`else
+,       .msi_noc1_axi_awaddr             ( msi_noc1_axi_awaddr           )
+,       .msi_noc1_axi_awvalid            ( msi_noc1_axi_awvalid          )
+,       .noc1_msi_axi_awready            ( noc1_msi_axi_awready          )
+
+,       .msi_noc1_axi_wdata              ( msi_noc1_axi_wdata            )
+,       .msi_noc1_axi_wstrb              ( msi_noc1_axi_wstrb            )
+,       .msi_noc1_axi_wvalid             ( msi_noc1_axi_wvalid           )
+,       .noc1_msi_axi_wready             ( noc1_msi_axi_wready           )
+
+,       .noc1_msi_axi_bresp              ( noc1_msi_axi_bresp            )
+,       .noc1_msi_axi_bvalid             ( noc1_msi_axi_bvalid           )
+,       .msi_noc1_axi_bready             ( msi_noc1_axi_bready           )
+
+,       .msi_noc1_axi_araddr             ( msi_noc1_axi_araddr           )
+,       .msi_noc1_axi_arvalid            ( msi_noc1_axi_arvalid          )
+,       .noc1_msi_axi_arready            ( noc1_msi_axi_arready          )
+
+,       .noc1_msi_axi_rdata              ( noc1_msi_axi_rdata            )
+,       .noc1_msi_axi_rresp              ( noc1_msi_axi_rresp            )
+,       .noc1_msi_axi_rvalid             ( noc1_msi_axi_rvalid           )
+,       .msi_noc1_axi_rready             ( msi_noc1_axi_rready           )
+// MSI request to NoC1
+,       .noc1_valid_out                  ( chipset_intf_val_noc1         )
+,       .noc1_data_out                   ( chipset_intf_data_noc1        )
+,       .noc1_ready_in                   ( chipset_intf_rdy_noc1         )
+// NoC2 request to MSI
+,       .noc2_valid_in                   ( intf_chipset_val_noc2         )
+,       .noc2_data_in                    ( intf_chipset_data_noc2        )
+,       .noc2_ready_out                  ( msi_noc2_rdy                )
+`endif // `ifdef DIRECT_MODE 
+`endif // `ifdef PITON_RV64_PLIC
     );
 ''' % (int(DmBase), int(RomBase), int(ClintBase), int(PlicBase))
 print(str)

--- a/piton/design/include/define.h.pyv
+++ b/piton/design/include/define.h.pyv
@@ -580,6 +580,13 @@ print("`define PITON_Y_TILES %d"   % PITON_Y_TILES)
 `define PICORV32_TILE    1
 `define ARIANE_RV64_TILE 2
 
+`ifdef DIRECT_MODE
+`define NR_IDCs          `PITON_NUM_TILES
+`define NR_DOMAINS       2
+`else
+`define NR_IDCs          0
+`endif
+
 `endif
 
 

--- a/piton/design/include/define.h.pyv
+++ b/piton/design/include/define.h.pyv
@@ -76,6 +76,7 @@ print("`define PITON_Y_TILES %d"   % PITON_Y_TILES)
 `define NOC_FBITS_L2        4'd0
 `define NOC_FBITS_FP        4'd0
 `define NOC_FBITS_MEM       4'd2
+`define NOC_FBITS_AIA       4'b1110
 
 `define NOC_NODEID_WIDTH    34
 `define NOC_DATACOUNT_WIDTH 5
@@ -453,6 +454,8 @@ print("`define PITON_Y_TILES %d"   % PITON_Y_TILES)
  `define ON_CHIP_DEV_X_POS       31:28
  `define ON_CHIP_DEV_Y_POS       27:24
  `define ON_CHIP_DEV_FBITS       23:20
+
+`define AIA_IMSIC_FLATID_POS     `HOME_ID_WIDTH+12-1:12
 
 // Packet format for home id
 `define PACKET_HOME_ID_WIDTH        (`NOC_CHIPID_WIDTH+`NOC_X_WIDTH+`NOC_Y_WIDTH)

--- a/piton/design/rtl/system.v
+++ b/piton/design/rtl/system.v
@@ -529,28 +529,6 @@ wire  [`PITON_NUM_TILES*2-1:0] irq;         // level sensitive IR lines, mip & s
 // APLIC
 `ifdef DIRECT_MODE
 wire [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]   irq;   
-`else
-wire [31:0]                          msi_noc1_axi_awaddr;
-wire                                 msi_noc1_axi_awvalid;
-wire                                 noc1_msi_axi_awready;
-  
-wire [31:0]                          msi_noc1_axi_wdata;
-wire [3:0]                           msi_noc1_axi_wstrb;
-wire                                 msi_noc1_axi_wvalid;
-wire                                 noc1_msi_axi_wready;
-  
-wire [1:0]                           noc1_msi_axi_bresp;
-wire                                 noc1_msi_axi_bvalid;
-wire                                 msi_noc1_axi_bready;
-  
-wire [31:0]                          msi_noc1_axi_araddr;
-wire                                 msi_noc1_axi_arvalid;
-wire                                 noc1_msi_axi_arready;
-  
-wire [31:0]                          noc1_msi_axi_rdata;
-wire [1:0]                           noc1_msi_axi_rresp;
-wire                                 noc1_msi_axi_rvalid;
-wire                                 msi_noc1_axi_rready;
 `endif // DIRECT_MODE
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
@@ -857,28 +835,6 @@ chip chip(
 `elsif PITON_RV64_APLIC
 `ifdef DIRECT_MODE
     ,.irq_i                         ( irq                        )
-`else
-    ,.msi_noc1_axi_awaddr           ( msi_noc1_axi_awaddr        )
-    ,.msi_noc1_axi_awvalid          ( msi_noc1_axi_awvalid       )
-    ,.noc1_msi_axi_awready          ( noc1_msi_axi_awready       )
-    
-    ,.msi_noc1_axi_wdata            ( msi_noc1_axi_wdata         )
-    ,.msi_noc1_axi_wstrb            ( msi_noc1_axi_wstrb         )
-    ,.msi_noc1_axi_wvalid           ( msi_noc1_axi_wvalid        )
-    ,.noc1_msi_axi_wready           ( noc1_msi_axi_wready        )
-    
-    ,.noc1_msi_axi_bresp            ( noc1_msi_axi_bresp         )
-    ,.noc1_msi_axi_bvalid           ( noc1_msi_axi_bvalid        )
-    ,.msi_noc1_axi_bready           ( msi_noc1_axi_bready        )
-    
-    ,.msi_noc1_axi_araddr           ( msi_noc1_axi_araddr        )
-    ,.msi_noc1_axi_arvalid          ( msi_noc1_axi_arvalid       )
-    ,.noc1_msi_axi_arready          ( noc1_msi_axi_arready       )
-    
-    ,.noc1_msi_axi_rdata            ( noc1_msi_axi_rdata         )
-    ,.noc1_msi_axi_rresp            ( noc1_msi_axi_rresp         )
-    ,.noc1_msi_axi_rvalid           ( noc1_msi_axi_rvalid        )
-    ,.msi_noc1_axi_rready           ( msi_noc1_axi_rready        )
 `endif // ifdef DIRECT_MODE
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
@@ -1290,28 +1246,6 @@ chipset chipset(
 `elsif PITON_RV64_APLIC
 `ifdef DIRECT_MODE
     ,.irq_o                         ( irq                        )
-`else
-    ,.msi_noc1_axi_awaddr           ( msi_noc1_axi_awaddr        )
-    ,.msi_noc1_axi_awvalid          ( msi_noc1_axi_awvalid       )
-    ,.noc1_msi_axi_awready          ( noc1_msi_axi_awready       )
-    
-    ,.msi_noc1_axi_wdata            ( msi_noc1_axi_wdata         )
-    ,.msi_noc1_axi_wstrb            ( msi_noc1_axi_wstrb         )
-    ,.msi_noc1_axi_wvalid           ( msi_noc1_axi_wvalid        )
-    ,.noc1_msi_axi_wready           ( noc1_msi_axi_wready        )
-    
-    ,.noc1_msi_axi_bresp            ( noc1_msi_axi_bresp         )
-    ,.noc1_msi_axi_bvalid           ( noc1_msi_axi_bvalid        )
-    ,.msi_noc1_axi_bready           ( msi_noc1_axi_bready        )
-    
-    ,.msi_noc1_axi_araddr           ( msi_noc1_axi_araddr        )
-    ,.msi_noc1_axi_arvalid          ( msi_noc1_axi_arvalid       )
-    ,.noc1_msi_axi_arready          ( noc1_msi_axi_arready       )
-    
-    ,.noc1_msi_axi_rdata            ( noc1_msi_axi_rdata         )
-    ,.noc1_msi_axi_rresp            ( noc1_msi_axi_rresp         )
-    ,.noc1_msi_axi_rvalid           ( noc1_msi_axi_rvalid        )
-    ,.msi_noc1_axi_rready           ( msi_noc1_axi_rready        )
 `endif // ifdef DIRECT_MODE
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM

--- a/piton/design/rtl/system.v
+++ b/piton/design/rtl/system.v
@@ -525,6 +525,33 @@ wire  [`PITON_NUM_TILES-1:0]   ipi;         // software interrupt (a.k.a inter-p
 `ifdef PITON_RV64_PLIC
 // PLIC
 wire  [`PITON_NUM_TILES*2-1:0] irq;         // level sensitive IR lines, mip & sip (async)
+`elsif  PITON_RV64_APLIC
+// APLIC
+`ifdef DIRECT_MODE
+wire [`PITON_NUM_TILES-1:0][(`NR_DOMAINS*`NR_IDCs)-1:0]   irq;   
+`else
+wire [31:0]                          msi_noc1_axi_awaddr;
+wire                                 msi_noc1_axi_awvalid;
+wire                                 noc1_msi_axi_awready;
+  
+wire [31:0]                          msi_noc1_axi_wdata;
+wire [3:0]                           msi_noc1_axi_wstrb;
+wire                                 msi_noc1_axi_wvalid;
+wire                                 noc1_msi_axi_wready;
+  
+wire [1:0]                           noc1_msi_axi_bresp;
+wire                                 noc1_msi_axi_bvalid;
+wire                                 msi_noc1_axi_bready;
+  
+wire [31:0]                          msi_noc1_axi_araddr;
+wire                                 msi_noc1_axi_arvalid;
+wire                                 noc1_msi_axi_arready;
+  
+wire [31:0]                          noc1_msi_axi_rdata;
+wire [1:0]                           noc1_msi_axi_rresp;
+wire                                 noc1_msi_axi_rvalid;
+wire                                 msi_noc1_axi_rready;
+`endif // DIRECT_MODE
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
 
@@ -827,6 +854,32 @@ chip chip(
 `ifdef PITON_RV64_PLIC
     // PLIC
     ,.irq_i                         ( irq                        )  // level sensitive IR lines, mip & sip (async)
+`elsif PITON_RV64_APLIC
+`ifdef DIRECT_MODE
+    ,.irq_i                         ( irq                        )
+`else
+    ,.msi_noc1_axi_awaddr           ( msi_noc1_axi_awaddr        )
+    ,.msi_noc1_axi_awvalid          ( msi_noc1_axi_awvalid       )
+    ,.noc1_msi_axi_awready          ( noc1_msi_axi_awready       )
+    
+    ,.msi_noc1_axi_wdata            ( msi_noc1_axi_wdata         )
+    ,.msi_noc1_axi_wstrb            ( msi_noc1_axi_wstrb         )
+    ,.msi_noc1_axi_wvalid           ( msi_noc1_axi_wvalid        )
+    ,.noc1_msi_axi_wready           ( noc1_msi_axi_wready        )
+    
+    ,.noc1_msi_axi_bresp            ( noc1_msi_axi_bresp         )
+    ,.noc1_msi_axi_bvalid           ( noc1_msi_axi_bvalid        )
+    ,.msi_noc1_axi_bready           ( msi_noc1_axi_bready        )
+    
+    ,.msi_noc1_axi_araddr           ( msi_noc1_axi_araddr        )
+    ,.msi_noc1_axi_arvalid          ( msi_noc1_axi_arvalid       )
+    ,.noc1_msi_axi_arready          ( noc1_msi_axi_arready       )
+    
+    ,.noc1_msi_axi_rdata            ( noc1_msi_axi_rdata         )
+    ,.noc1_msi_axi_rresp            ( noc1_msi_axi_rresp         )
+    ,.noc1_msi_axi_rvalid           ( noc1_msi_axi_rvalid        )
+    ,.msi_noc1_axi_rready           ( msi_noc1_axi_rready        )
+`endif // ifdef DIRECT_MODE
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
 );
@@ -1234,6 +1287,32 @@ chipset chipset(
 `ifdef PITON_RV64_PLIC
     // PLIC
     ,.irq_o                         ( irq                        ) // level sensitive IR lines, mip & sip (async)
+`elsif PITON_RV64_APLIC
+`ifdef DIRECT_MODE
+    ,.irq_o                         ( irq                        )
+`else
+    ,.msi_noc1_axi_awaddr           ( msi_noc1_axi_awaddr        )
+    ,.msi_noc1_axi_awvalid          ( msi_noc1_axi_awvalid       )
+    ,.noc1_msi_axi_awready          ( noc1_msi_axi_awready       )
+    
+    ,.msi_noc1_axi_wdata            ( msi_noc1_axi_wdata         )
+    ,.msi_noc1_axi_wstrb            ( msi_noc1_axi_wstrb         )
+    ,.msi_noc1_axi_wvalid           ( msi_noc1_axi_wvalid        )
+    ,.noc1_msi_axi_wready           ( noc1_msi_axi_wready        )
+    
+    ,.noc1_msi_axi_bresp            ( noc1_msi_axi_bresp         )
+    ,.noc1_msi_axi_bvalid           ( noc1_msi_axi_bvalid        )
+    ,.msi_noc1_axi_bready           ( msi_noc1_axi_bready        )
+    
+    ,.msi_noc1_axi_araddr           ( msi_noc1_axi_araddr        )
+    ,.msi_noc1_axi_arvalid          ( msi_noc1_axi_arvalid       )
+    ,.noc1_msi_axi_arready          ( noc1_msi_axi_arready       )
+    
+    ,.noc1_msi_axi_rdata            ( noc1_msi_axi_rdata         )
+    ,.noc1_msi_axi_rresp            ( noc1_msi_axi_rresp         )
+    ,.noc1_msi_axi_rvalid           ( noc1_msi_axi_rvalid        )
+    ,.msi_noc1_axi_rready           ( msi_noc1_axi_rready        )
+`endif // ifdef DIRECT_MODE
 `endif // ifdef PITON_RV64_PLIC
 `endif // ifdef PITON_RV64_PLATFORM
 

--- a/piton/tools/src/sims/manycore.config
+++ b/piton/tools/src/sims/manycore.config
@@ -69,8 +69,10 @@
     -config_rtl=PITON_RV64_PLATFORM
     -config_rtl=PITON_RV64_DEBUGUNIT
     -config_rtl=PITON_RV64_CLINT
-    -config_rtl=PITON_RV64_PLIC
+    //-config_rtl=PITON_RV64_PLIC
     -config_rtl=WT_DCACHE
+    -config_rtl=PITON_RV64_APLIC
+    -config_rtl=DIRECT_MODE
 #endif
     -flist=$DV_ROOT/design/chip/tile/common/rtl/Flist.clib_common
     -flist=$DV_ROOT/design/chip/tile/common/rtl/Flist.dlib_common
@@ -97,6 +99,7 @@
     -flist=$DV_ROOT/verif/env/manycore/manycore.flist
     -flist=$DV_ROOT/verif/env/common/fake_mem_ctrl.flist
     -flist=$DV_ROOT/design/chipset/noc_axilite_bridge/rtl/Flist.noc_axilite_bridge
+    -flist=$DV_ROOT/design/chipset/axilite_noc_bridge/rtl/Flist.axilite_noc_bridge    
     -flist=$DV_ROOT/design/chipset/io_xbar/rtl/Flist.io_xbar
     -flist=$DV_ROOT/design/chipset/io_xbar/common/rtl/Flist.common
     -flist=$DV_ROOT/design/chipset/io_xbar/dynamic/rtl/Flist.dynamic

--- a/piton/verif/diag/c/riscv/ariane/aplic_direct_access.c
+++ b/piton/verif/diag/c/riscv/ariane/aplic_direct_access.c
@@ -1,0 +1,67 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 26.11.2018
+// Description: Simple hello world program that prints 32 times "hello world".
+//
+
+#include <stdio.h>
+
+
+#define NHARTS       1
+#define PLIC_SOURCES 2
+#define CLINT_BASE   0xfff1020000ULL
+#define PLIC_BASE    0xfff1100000ULL 
+
+int main(int argc, char ** argv) {
+
+  printf("Reading APLIC registers...\n");
+  
+  // only use core 0 to perform test
+  if(argv[0][0] == 0) {
+
+      //uint64_t *addr;
+      //// PLIC Register
+      //for (uint64_t k = 0; k < NHARTS; k++) {
+      //    addr = (uint64_t*)(PLIC_BASE + k*8);
+      //    *addr = 0xdeadbeef;
+      //    uint64_t val;
+      //    val = *addr;
+      //    printf("Addr = 0x%x",addr);
+      //    printf("Val: result = 0x%x\n",val);
+      //}
+      //printf("Done!\n");
+
+      uint64_t *addr;
+      //int val;
+      // APLIC Register
+      for (uint64_t k = 0; k < NHARTS; k++) {
+          addr = (uint64_t*)(PLIC_BASE + 0x3000);
+          *addr = 0x1eff;
+          uint64_t val;
+          val = *addr;
+          printf("ADDR : 0x%lx\n",addr);
+          printf("VAL: 0x%x\n",val);
+
+          //if ( val == 0xdeadbeef ){
+          //  printf("PASS!");
+          //  return 0;
+          //}
+          //else{
+          //  printf("FAILED");
+          //  return 1;
+          //}
+      }
+      printf("Done!\n");
+  }
+      
+  return 0;
+}

--- a/piton/verif/env/manycore/devices_ariane.xml
+++ b/piton/verif/env/manycore/devices_ariane.xml
@@ -62,6 +62,12 @@ Description: Peripheral address map for OpenPiton+Ariane configurations.
         <base>0xfff1020000</base>
         <length>0xc0000</length>
     </port>
+    <port>
+        <!-- Advanced platform level interrupt controller -->
+        <name>ariane_aia</name>
+        <base>0xe300000000</base>
+        <length>0x4000000</length>
+    </port>
     <!-- platform level interrupt controller -->
     <port>
         <name>ariane_plic</name>


### PR DESCRIPTION
The PR aims to integrate AIA IP by Zero-Day Labs into OP.

AIA IP comprises APLIC (Advanced PLIC) for handling wired interrupts and IMSIC (Incoming Message Signaled Interrupt controller) for handling messaged signaled interrupts.

There are two modes that an APLIC supports:

1. Direct Mode
2. MSI Mode

In MSI mode, the role of an APLIC is to convert wired interrupts into MSI and send them to IMSIC for further handling. We are using NoC1 for sending the MSi requests from APLIC to IMSIC and NoC2 as a response. IMSIC is tightly coupled with the tile.

More details: [Read the blog here](https://medium.com/@kinzahqamarzaman/enhancing-openpiton-ariane-soc-with-an-open-source-advanced-interrupt-architecture-AIA-7504bb308b16)