### PR TITLE
setup.tcl preserve error messages

### DIFF
--- a/piton/tools/src/proto/common/setup.tcl
+++ b/piton/tools/src/proto/common/setup.tcl
@@ -135,8 +135,8 @@ if  {[info exists ::env(PITON_ARIANE)]} {
   cd $::env(DV_ROOT)/design/chipset/rv64_platform/bootrom/baremetal
   # Note: dd dumps info to stderr that we do not want to interpret
   # otherwise this command fails...
-  exec make clean 2> /dev/null
-  exec make all 2> /dev/null
+  exec make clean 2>@1
+  exec make all 2>@1
   puts "INFO: bare metal firmware generation complete"
   if {[info exists ::env(PITON_UBOOT_SPL)]} {
     cd $::env(DV_ROOT)/design/chipset/rv64_platform/bootrom
@@ -150,14 +150,14 @@ if  {[info exists ::env(PITON_ARIANE)]} {
     # exec git checkout dual-core
     # Note: dd dumps info to stderr that we do not want to interpret
     # otherwise this command fails...
-    exec make distclean 2> /dev/null
+    exec make distclean 2>@1
     exec make ARCH=riscv CROSS_COMPILE=riscv-none-embed- openpiton_riscv64_spl_defconfig
     #TODO: update riscv toochain
-    exec make CROSS_COMPILE=riscv-none-embed- -j8 2> /dev/null
+    exec make CROSS_COMPILE=riscv-none-embed- -j8 2>@1
     # generate mover using the spl image
     cd $::env(PITON_ROOT)/piton/design/chipset/rv64_platform/bootrom/u-boot/mover/
     exec make clean
-    exec make 2> /dev/null
+    exec make 2>@1
     # generate the linux bootrom using mover image
     exec cp mover.sv $::env(PITON_ROOT)/piton/design/chipset/rv64_platform/bootrom/linux/bootrom_linux.sv
     cd $::env(PITON_ROOT)/piton/design/chipset/rv64_platform/bootrom/linux/
@@ -166,8 +166,8 @@ if  {[info exists ::env(PITON_ARIANE)]} {
     cd $::env(DV_ROOT)/design/chipset/rv64_platform/bootrom/linux
     # Note: dd dumps info to stderr that we do not want to interpret
     # otherwise this command fails...
-    exec make clean 2> /dev/null
-    exec make all MAX_HARTS=$::env(PITON_NUM_TILES) UART_FREQ=$::env(CONFIG_SYS_FREQ) 2> /dev/null
+    exec make clean 2>@1
+    exec make all MAX_HARTS=$::env(PITON_NUM_TILES) UART_FREQ=$::env(CONFIG_SYS_FREQ) 2>@1
   }
   puts "INFO: done"
   # two targets per hart (M,S) and two interrupt sources (UART, Ethernet)


### PR DESCRIPTION
Currently the make calls redirecting the stderr
to dev/null which leads to extra steps to figure out what went wrong. 
Instead of dropping the error redirecting it to the stdout.