### PR TITLE
Fix l2 pipe1 typo causing wrong hazard detection

### DIFF
--- a/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
+++ b/piton/design/chip/tile/l2/rtl/l2_pipe1_ctrl.v.pyv
@@ -2237,7 +2237,7 @@ begin
     &&  (~special_addr_type_S2_f)
     &&  ((pipe2_valid_S1 && (pipe2_msg_type_S1 == `MSG_TYPE_WB_REQ)
         && (addr_S2[`L2_TAG_PLUS_INDEX] == pipe2_addr_S1[`L2_TAG_PLUS_INDEX]))
-    ||   (pipe2_valid_S2 && (pipe2_msg_type_S1 == `MSG_TYPE_WB_REQ)
+    ||   (pipe2_valid_S2 && (pipe2_msg_type_S2 == `MSG_TYPE_WB_REQ)
         && (addr_S2[`L2_TAG_PLUS_INDEX] == pipe2_addr_S2[`L2_TAG_PLUS_INDEX]))
     ||   (pipe2_valid_S3 && (pipe2_msg_type_S3 == `MSG_TYPE_WB_REQ)
         && (addr_S2[`L2_TAG_PLUS_INDEX] == pipe2_addr_S3[`L2_TAG_PLUS_INDEX])));


### PR DESCRIPTION
L2 pipe 1 checks the requests being processed in pipe 2 to detect cases in which it should stall or "recycle" current requests. It does so by checking the valid, request type and request address bits. However, there is a typo by which it checks the Stage 1 message type instead of Stage 2's.