### PR TITLE
Fix: Verilator simulations now generate valid dumps after interruption

### DIFF
--- a/piton/tools/verilator/my_top.cpp
+++ b/piton/tools/verilator/my_top.cpp
@@ -27,6 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Vcmp_top.h"
 #include "verilated.h"
 #include <iostream>
+#include <csignal>
 #ifdef VERILATOR_VCD
 #include "verilated_vcd_c.h"
 #endif
@@ -143,6 +144,17 @@ void reset_and_init() {
     std::cout << "Reset complete" << std::endl << std::flush;
 }
 
+void exit_handler(int _signal) {
+    std::cout << "Interrupted!" << std::endl;
+    
+    #if defined(VERILATOR_VCD) || defined(VERILATOR_FST)
+    std::cout << "Trace done" << std::endl;
+    tfp->close();
+    #endif
+    
+    exit(1);
+}
+
 int main(int argc, char **argv, char **env) {
 std::cout << "Started" << std::endl << std::flush;
 Verilated::commandArgs(argc, argv);
@@ -157,6 +169,12 @@ tfp->open ("my_top.vcd");
 
 Verilated::debug(1);
 #endif
+
+std::signal(SIGINT, exit_handler);
+std::signal(SIGTERM, exit_handler);
+std::signal(SIGSEGV, exit_handler);
+std::signal(SIGABRT, exit_handler);
+std::signal(SIGILL, exit_handler);
 
 reset_and_init();
 


### PR DESCRIPTION
If a verilator simulation stalls and its killed by `ctrl+c`, the generated dump ends up being invalid, requiring a rerun with `+max_cycles` or other flags that cleanly end the simulation. This commit adds a signal handler to the verilator `main` routine that properly closes the dump file before exiting.
