### PR TITLE
Remove duplicated retiming definition

### DIFF
--- a/piton/tools/src/proto/vivado/gen_project.tcl
+++ b/piton/tools/src/proto/vivado/gen_project.tcl
@@ -267,7 +267,6 @@ set_property STEPS.SYNTH_DESIGN.ARGS.FSM_EXTRACTION auto [get_runs synth_1]
 set_property STEPS.SYNTH_DESIGN.ARGS.KEEP_EQUIVALENT_REGISTERS false [get_runs synth_1]
 set_property STEPS.SYNTH_DESIGN.ARGS.RESOURCE_SHARING auto [get_runs synth_1]
 set_property STEPS.SYNTH_DESIGN.ARGS.NO_LC false [get_runs synth_1]
-set_property STEPS.SYNTH_DESIGN.ARGS.RETIMING true [get_runs synth_1]
 set_property STEPS.SYNTH_DESIGN.ARGS.CONTROL_SET_OPT_THRESHOLD auto [get_runs synth_1]
 
 #set_property "incremental_checkpoint" "" $fileset_obj


### PR DESCRIPTION
The option to set the retiming property to true for the synth_1 run was duplicated.